### PR TITLE
feat(mysql-cli): enhance MySQL CLI with protocol support display and database introspection

### DIFF
--- a/changelog.d/12.added.md
+++ b/changelog.d/12.added.md
@@ -1,0 +1,1 @@
+Added MySQL CLI protocol support display with database introspection for version detection, enabling users to view detailed feature availability based on actual server version.

--- a/src/rhosocial/activerecord/backend/impl/mysql/__main__.py
+++ b/src/rhosocial/activerecord/backend/impl/mysql/__main__.py
@@ -1,31 +1,85 @@
 # src/rhosocial/activerecord/backend/impl/mysql/__main__.py
+"""
+MySQL backend command-line interface.
+
+Provides SQL execution and database information display capabilities.
+"""
 import argparse
 import asyncio
+import inspect
+import json
 import logging
 import os
 import sys
+from typing import Dict, List, Any, Optional, Tuple
 
 from . import MySQLBackend, AsyncMySQLBackend
 from .config import MySQLConnectionConfig
+from .dialect import MySQLDialect
 from rhosocial.activerecord.backend.errors import ConnectionError, QueryError
-from rhosocial.activerecord.backend.output import JsonOutputProvider, CsvOutputProvider, TsvOutputProvider
+from rhosocial.activerecord.backend.output import (
+    JsonOutputProvider, CsvOutputProvider, TsvOutputProvider
+)
+from rhosocial.activerecord.backend.dialect.protocols import (
+    WindowFunctionSupport, CTESupport, FilterClauseSupport,
+    ReturningSupport, UpsertSupport, LateralJoinSupport, JoinSupport,
+    JSONSupport, ExplainSupport, GraphSupport,
+    SetOperationSupport, ViewSupport,
+    TableSupport, TruncateSupport, GeneratedColumnSupport,
+    TriggerSupport, FunctionSupport,
+    AdvancedGroupingSupport, ArraySupport, ILIKESupport,
+    IndexSupport, LockingSupport, MergeSupport,
+    OrderedSetAggregationSupport, QualifyClauseSupport,
+    SchemaSupport, SequenceSupport, TemporalTableSupport,
+)
+from .protocols import (
+    MySQLTriggerSupport,
+    MySQLTableSupport,
+    MySQLSetTypeSupport,
+    MySQLJSONFunctionSupport,
+    MySQLSpatialSupport,
+)
 
 # Attempt to import rich for formatted output
 try:
-    from rich.console import Console
     from rich.logging import RichHandler
     from rhosocial.activerecord.backend.output_rich import RichOutputProvider
     RICH_AVAILABLE = True
 except ImportError:
     RICH_AVAILABLE = False
-    RichOutputProvider = None
+    RichOutputProvider = None  # type: ignore[misc,assignment]
 
 logger = logging.getLogger(__name__)
+
+# Protocol family groups for display
+PROTOCOL_FAMILY_GROUPS: Dict[str, list] = {
+    "Query Features": [
+        WindowFunctionSupport, CTESupport, FilterClauseSupport,
+        SetOperationSupport, AdvancedGroupingSupport,
+    ],
+    "JOIN Support": [JoinSupport, LateralJoinSupport],
+    "Data Types": [JSONSupport, ArraySupport],
+    "DML Features": [
+        ReturningSupport, UpsertSupport, MergeSupport,
+        OrderedSetAggregationSupport,
+    ],
+    "Transaction & Locking": [LockingSupport, TemporalTableSupport],
+    "Query Analysis": [ExplainSupport, GraphSupport, QualifyClauseSupport],
+    "DDL - Table": [TableSupport, TruncateSupport, GeneratedColumnSupport],
+    "DDL - View": [ViewSupport],
+    "DDL - Schema & Index": [SchemaSupport, IndexSupport],
+    "DDL - Sequence & Trigger": [SequenceSupport, TriggerSupport, FunctionSupport],
+    "String Matching": [ILIKESupport],
+    "MySQL-specific": [
+        MySQLTriggerSupport, MySQLTableSupport,
+        MySQLSetTypeSupport, MySQLJSONFunctionSupport, MySQLSpatialSupport,
+    ],
+}
 
 
 def parse_args():
     parser = argparse.ArgumentParser(
-        description="Execute a single SQL query against a MySQL backend.",
+        description="Execute SQL queries against a MySQL backend.",
         formatter_class=argparse.RawTextHelpFormatter
     )
     # Input source arguments
@@ -38,16 +92,41 @@ def parse_args():
     parser.add_argument(
         '-f', '--file',
         default=None,
-        help='Path to a file containing a single SQL query to execute.'
+        help='Path to a file containing SQL to execute.'
     )
     # Connection parameters
-    parser.add_argument('--host', default=os.getenv('MYSQL_HOST', 'localhost'), help='Database host')
-    parser.add_argument('--port', type=int, default=int(os.getenv('MYSQL_PORT', 3306)), help='Database port')
-    parser.add_argument('--database', default=os.getenv('MYSQL_DATABASE'), help='Database name')
-    parser.add_argument('--user', default=os.getenv('MYSQL_USER', 'root'), help='Database user')
-    parser.add_argument('--password', default=os.getenv('MYSQL_PASSWORD', ''), help='Database password')
-    parser.add_argument('--charset', default=os.getenv('MYSQL_CHARSET', 'utf8mb4'), help='Connection charset')
-    
+    parser.add_argument(
+        '--host',
+        default=os.getenv('MYSQL_HOST', 'localhost'),
+        help='Database host'
+    )
+    parser.add_argument(
+        '--port',
+        type=int,
+        default=int(os.getenv('MYSQL_PORT', '3306')),
+        help='Database port'
+    )
+    parser.add_argument(
+        '--database',
+        default=os.getenv('MYSQL_DATABASE'),
+        help='Database name'
+    )
+    parser.add_argument(
+        '--user',
+        default=os.getenv('MYSQL_USER', 'root'),
+        help='Database user'
+    )
+    parser.add_argument(
+        '--password',
+        default=os.getenv('MYSQL_PASSWORD', ''),
+        help='Database password'
+    )
+    parser.add_argument(
+        '--charset',
+        default=os.getenv('MYSQL_CHARSET', 'utf8mb4'),
+        help='Connection charset'
+    )
+
     # Execution options
     parser.add_argument('--use-async', action='store_true', help='Use asynchronous backend')
 
@@ -56,10 +135,37 @@ def parse_args():
         '--output',
         choices=['table', 'json', 'csv', 'tsv'],
         default='table',
-        help='Output format. Defaults to "table" if rich is installed, otherwise "json".'
+        help='Output format. Defaults to "table" if rich is installed.'
     )
-    parser.add_argument('--log-level', default='INFO', help='Set logging level (e.g., DEBUG, INFO)')
-    parser.add_argument('--rich-ascii', action='store_true', help='Use ASCII characters for rich table borders.')
+    parser.add_argument(
+        '--log-level',
+        default='INFO',
+        help='Set logging level (e.g., DEBUG, INFO)'
+    )
+    parser.add_argument(
+        '--rich-ascii',
+        action='store_true',
+        help='Use ASCII characters for rich table borders.'
+    )
+
+    # Info display options
+    parser.add_argument(
+        '--info',
+        action='store_true',
+        help='Display MySQL environment information.'
+    )
+    parser.add_argument(
+        '-v', '--verbose',
+        action='count',
+        default=0,
+        help='Increase verbosity. -v for families, -vv for details.'
+    )
+    parser.add_argument(
+        '--version',
+        type=str,
+        default=None,
+        help='MySQL version to simulate (e.g., "8.0.0", "5.7.8"). Default: 8.0.0.'
+    )
 
     return parser.parse_args()
 
@@ -70,7 +176,8 @@ def get_provider(args):
     if output_format == 'table' and not RICH_AVAILABLE:
         output_format = 'json'
 
-    if output_format == 'table':
+    if output_format == 'table' and RICH_AVAILABLE:
+        from rich.console import Console
         return RichOutputProvider(console=Console(), ascii_borders=args.rich_ascii)
     if output_format == 'json':
         return JsonOutputProvider()
@@ -78,16 +185,158 @@ def get_provider(args):
         return CsvOutputProvider()
     if output_format == 'tsv':
         return TsvOutputProvider()
-    
+
     return JsonOutputProvider()
 
 
-def execute_query_sync(sql_query: str, backend: MySQLBackend, provider: 'OutputProvider', **kwargs):
+def get_protocol_support_methods(protocol_class: type) -> List[str]:
+    """Get all supports_* methods from a protocol class."""
+    methods = []
+    for name, member in inspect.getmembers(protocol_class):
+        if name.startswith('supports_') and callable(member):
+            methods.append(name)
+    return sorted(methods)
+
+
+def check_protocol_support(dialect: MySQLDialect, protocol_class: type) -> Dict[str, bool]:
+    """Check all support methods for a protocol against the dialect."""
+    results = {}
+    methods = get_protocol_support_methods(protocol_class)
+    for method_name in methods:
+        if hasattr(dialect, method_name):
+            try:
+                result = getattr(dialect, method_name)()
+                results[method_name] = bool(result)
+            except Exception:
+                results[method_name] = False
+        else:
+            results[method_name] = False
+    return results
+
+
+def parse_version(version_str: str) -> Tuple[int, int, int]:
+    """Parse version string like '8.0.0' to tuple."""
+    parts = version_str.split('.')
+    major = int(parts[0]) if len(parts) > 0 else 0
+    minor = int(parts[1]) if len(parts) > 1 else 0
+    patch = int(parts[2]) if len(parts) > 2 else 0
+    return (major, minor, patch)
+
+
+def display_info(verbose: int = 0, output_format: str = 'table',
+                 version_str: Optional[str] = None):
+    """Display MySQL environment information."""
+    # Parse version
+    if version_str:
+        version = parse_version(version_str)
+    else:
+        version = (8, 0, 0)  # Default version
+
+    dialect = MySQLDialect(version=version)
+    version_display = f"{version[0]}.{version[1]}.{version[2]}"
+
+    info = {
+        "mysql": {
+            "version": version_display,
+            "version_tuple": list(version),
+        },
+        "protocols": {}
+    }
+
+    for group_name, protocols in PROTOCOL_FAMILY_GROUPS.items():
+        info["protocols"][group_name] = {}
+        for protocol in protocols:
+            protocol_name = protocol.__name__
+            support_methods = check_protocol_support(dialect, protocol)
+            supported_count = sum(1 for v in support_methods.values() if v)
+            total_count = len(support_methods)
+
+            if verbose >= 2:
+                info["protocols"][group_name][protocol_name] = {
+                    "supported": supported_count,
+                    "total": total_count,
+                    "percentage": (round(supported_count / total_count * 100, 1)
+                                   if total_count > 0 else 0),
+                    "methods": support_methods
+                }
+            else:
+                info["protocols"][group_name][protocol_name] = {
+                    "supported": supported_count,
+                    "total": total_count,
+                    "percentage": (round(supported_count / total_count * 100, 1)
+                                   if total_count > 0 else 0)
+                }
+
+    if output_format == 'json' or not RICH_AVAILABLE:
+        print(json.dumps(info, indent=2))
+    else:
+        _display_info_rich(info, verbose, version_display)
+
+    return info
+
+
+def _display_info_rich(info: Dict, verbose: int, version_display: str):
+    """Display info using rich console."""
+    from rich.console import Console
+
+    console = Console(force_terminal=True)
+
+    SYM_OK = "[OK]"
+    SYM_PARTIAL = "[~]"
+    SYM_FAIL = "[X]"
+
+    console.print("\n[bold cyan]MySQL Environment Information[/bold cyan]\n")
+
+    console.print(f"[bold]MySQL Version:[/bold] {version_display}\n")
+
+    label = 'Detailed' if verbose >= 2 else 'Family Overview'
+    console.print(f"[bold green]Protocol Support ({label}):[/bold green]")
+
+    for group_name, protocols in info["protocols"].items():
+        console.print(f"\n  [bold underline]{group_name}:[/bold underline]")
+        for protocol_name, stats in protocols.items():
+            pct = stats["percentage"]
+            if pct == 100:
+                color = "green"
+                symbol = SYM_OK
+            elif pct >= 50:
+                color = "yellow"
+                symbol = SYM_PARTIAL
+            elif pct > 0:
+                color = "red"
+                symbol = SYM_PARTIAL
+            else:
+                color = "red"
+                symbol = SYM_FAIL
+
+            bar_len = 20
+            filled = int(pct / 100 * bar_len)
+            progress_bar = "#" * filled + "-" * (bar_len - filled)
+
+            sup = stats['supported']
+            tot = stats['total']
+            console.print(
+                f"    [{color}]{symbol}[/{color}] {protocol_name}: "
+                f"[{color}]{progress_bar}[/{color}] {pct:.0f}% ({sup}/{tot})"
+            )
+
+            if verbose >= 2 and "methods" in stats:
+                for method, supported in stats["methods"].items():
+                    method_display = method.replace("supports_", "").replace("_", " ")
+                    m_status = "[green][OK][/green]" if supported else "[red][X][/red]"
+                    console.print(f"        {m_status} {method_display}")
+
+    console.print()
+
+
+def execute_query_sync(sql_query: str, backend: MySQLBackend,
+                       provider: Any, **kwargs):
+    """Execute a SQL query synchronously."""
     try:
         backend.connect()
         provider.display_query(sql_query, is_async=False)
         result = backend.execute(sql_query)
-        
+
         if not result:
             provider.display_no_result_object()
         else:
@@ -107,17 +356,19 @@ def execute_query_sync(sql_query: str, backend: MySQLBackend, provider: 'OutputP
         provider.display_unexpected_error(e, is_async=False)
         sys.exit(1)
     finally:
-        if backend._connection:
+        if backend._connection:  # type: ignore
             backend.disconnect()
             provider.display_disconnect(is_async=False)
 
 
-async def execute_query_async(sql_query: str, backend: AsyncMySQLBackend, provider: 'OutputProvider', **kwargs):
+async def execute_query_async(sql_query: str, backend: AsyncMySQLBackend,
+                              provider: Any, **kwargs):
+    """Execute a SQL query asynchronously."""
     try:
         await backend.connect()
         provider.display_query(sql_query, is_async=True)
         result = await backend.execute(sql_query)
-        
+
         if not result:
             provider.display_no_result_object()
         else:
@@ -137,13 +388,19 @@ async def execute_query_async(sql_query: str, backend: AsyncMySQLBackend, provid
         provider.display_unexpected_error(e, is_async=True)
         sys.exit(1)
     finally:
-        if backend._connection:
+        if backend._connection:  # type: ignore
             await backend.disconnect()
             provider.display_disconnect(is_async=True)
 
 
 def main():
     args = parse_args()
+
+    if args.info:
+        output_format = args.output if args.output != 'table' or RICH_AVAILABLE else 'json'
+        display_info(verbose=args.verbose, output_format=output_format,
+                     version_str=args.version)
+        return
 
     numeric_level = getattr(logging, args.log_level.upper(), None)
     if not isinstance(numeric_level, int):
@@ -152,16 +409,25 @@ def main():
     provider = get_provider(args)
 
     if RICH_AVAILABLE and isinstance(provider, RichOutputProvider):
+        from rich.console import Console
+        handler = RichHandler(
+            rich_tracebacks=True,
+            show_path=False,
+            console=Console(stderr=True)
+        )
         logging.basicConfig(
-            level=numeric_level, format="%(message)s", datefmt="[%X]",
-            handlers=[RichHandler(rich_tracebacks=True, show_path=False, console=Console(stderr=True))]
+            level=numeric_level,
+            format="%(message)s",
+            datefmt="[%X]",
+            handlers=[handler]
         )
     else:
         logging.basicConfig(
-            level=numeric_level, format='%(asctime)s - %(levelname)s - %(message)s',
+            level=numeric_level,
+            format='%(asctime)s - %(levelname)s - %(message)s',
             stream=sys.stderr
         )
-    
+
     provider.display_greeting()
 
     sql_source = None
@@ -178,12 +444,13 @@ def main():
         sql_source = sys.stdin.read()
 
     if not sql_source:
-        print("Error: No SQL query provided. Use the query argument, --file flag, or pipe from stdin.", file=sys.stderr)
+        msg = "Error: No SQL query provided. Use query argument, --file, or stdin."
+        print(msg, file=sys.stderr)
         sys.exit(1)
-    
-    # Ensure only one statement is provided, as multi-statement execution is not supported
+
+    # Ensure only one statement is provided
     if ';' in sql_source.strip().rstrip(';'):
-        logger.error("Error: Multiple SQL statements are not supported. Please provide a single query.")
+        logger.error("Error: Multiple SQL statements are not supported.")
         sys.exit(1)
 
     config = MySQLConnectionConfig(

--- a/src/rhosocial/activerecord/backend/impl/mysql/__main__.py
+++ b/src/rhosocial/activerecord/backend/impl/mysql/__main__.py
@@ -51,6 +51,9 @@ except ImportError:
 
 logger = logging.getLogger(__name__)
 
+# Groups that are specific to MySQL dialect
+DIALECT_SPECIFIC_GROUPS = {"MySQL-specific"}
+
 # Protocol family groups for display
 PROTOCOL_FAMILY_GROUPS: Dict[str, list] = {
     "Query Features": [
@@ -190,23 +193,78 @@ def get_provider(args):
 
 
 def get_protocol_support_methods(protocol_class: type) -> List[str]:
-    """Get all supports_* methods from a protocol class."""
+    """Get all support check methods from a protocol class.
+
+    Supports both 'supports_*' and 'is_*_available' naming patterns.
+    """
     methods = []
     for name, member in inspect.getmembers(protocol_class):
-        if name.startswith('supports_') and callable(member):
+        if callable(member) and (name.startswith('supports_') or name.startswith('is_') and name.endswith('_available')):
             methods.append(name)
     return sorted(methods)
 
 
-def check_protocol_support(dialect: MySQLDialect, protocol_class: type) -> Dict[str, bool]:
-    """Check all support methods for a protocol against the dialect."""
+# All possible test arguments for methods that require parameters
+# This allows detailed display of which specific arguments are supported
+SUPPORT_METHOD_ALL_ARGS: Dict[str, List[str]] = {
+    # ExplainSupport: all possible format types
+    'supports_explain_format': ['TEXT', 'JSON', 'TREE', 'XML', 'YAML', 'DOT'],
+    # MySQLJSONFunctionSupport: JSON functions with version-specific support
+    'supports_json_function': [
+        'JSON_EXTRACT', 'JSON_ARRAY', 'JSON_OBJECT', 'JSON_MERGE',
+        'JSON_TABLE', 'JSON_VALUE', 'JSON_SCHEMA_VALID', 'JSON_MERGE_PATCH'
+    ],
+    # MySQLSpatialSupport: spatial types
+    'supports_spatial_type': [
+        'GEOMETRY', 'POINT', 'LINESTRING', 'POLYGON',
+        'MULTIPOINT', 'MULTILINESTRING', 'MULTIPOLYGON', 'GEOMETRYCOLLECTION'
+    ],
+}
+
+
+def check_protocol_support(dialect: MySQLDialect, protocol_class: type) -> Dict[str, Any]:
+    """Check all support methods for a protocol against the dialect.
+
+    For methods requiring parameters, tests all possible arguments.
+
+    Returns:
+        Dict with method names as keys. For no-arg methods: bool value.
+        For methods with parameters: dict with 'supported', 'total', 'args' keys.
+    """
     results = {}
     methods = get_protocol_support_methods(protocol_class)
     for method_name in methods:
         if hasattr(dialect, method_name):
             try:
-                result = getattr(dialect, method_name)()
-                results[method_name] = bool(result)
+                method = getattr(dialect, method_name)
+                # Check if method requires arguments (beyond self)
+                sig = inspect.signature(method)
+                params = [p for p in sig.parameters.values()
+                          if p.default == inspect.Parameter.empty]
+                required_params = [p for p in params if p.name != 'self']
+
+                if len(required_params) == 0:
+                    # No required parameters, call directly
+                    result = method()
+                    results[method_name] = bool(result)
+                elif method_name in SUPPORT_METHOD_ALL_ARGS:
+                    # Test all possible arguments
+                    all_args = SUPPORT_METHOD_ALL_ARGS[method_name]
+                    arg_results = {}
+                    for arg in all_args:
+                        try:
+                            arg_results[arg] = bool(method(arg))
+                        except Exception:
+                            arg_results[arg] = False
+                    supported_count = sum(1 for v in arg_results.values() if v)
+                    results[method_name] = {
+                        'supported': supported_count,
+                        'total': len(all_args),
+                        'args': arg_results
+                    }
+                else:
+                    # Unknown method requiring parameters, skip
+                    results[method_name] = False
             except Exception:
                 results[method_name] = False
         else:
@@ -235,11 +293,14 @@ def display_info(verbose: int = 0, output_format: str = 'table',
     dialect = MySQLDialect(version=version)
     version_display = f"{version[0]}.{version[1]}.{version[2]}"
 
+    # Unified structure for JSON output
     info = {
-        "mysql": {
+        "database": {
+            "type": "mysql",
             "version": version_display,
             "version_tuple": list(version),
         },
+        "features": {},
         "protocols": {}
     }
 
@@ -248,8 +309,20 @@ def display_info(verbose: int = 0, output_format: str = 'table',
         for protocol in protocols:
             protocol_name = protocol.__name__
             support_methods = check_protocol_support(dialect, protocol)
-            supported_count = sum(1 for v in support_methods.values() if v)
-            total_count = len(support_methods)
+
+            # Calculate supported/total counts
+            # For no-arg methods: value is bool
+            # For methods with parameters: value is dict with 'supported', 'total', 'args'
+            supported_count = 0
+            total_count = 0
+            for method_name, value in support_methods.items():
+                if isinstance(value, dict):
+                    supported_count += value['supported']
+                    total_count += value['total']
+                else:
+                    total_count += 1
+                    if value:
+                        supported_count += 1
 
             if verbose >= 2:
                 info["protocols"][group_name][protocol_name] = {
@@ -270,7 +343,12 @@ def display_info(verbose: int = 0, output_format: str = 'table',
     if output_format == 'json' or not RICH_AVAILABLE:
         print(json.dumps(info, indent=2))
     else:
-        _display_info_rich(info, verbose, version_display)
+        # Use legacy structure for rich display
+        info_legacy = {
+            "mysql": info["database"],
+            "protocols": info["protocols"]
+        }
+        _display_info_rich(info_legacy, verbose, version_display)
 
     return info
 
@@ -293,7 +371,11 @@ def _display_info_rich(info: Dict, verbose: int, version_display: str):
     console.print(f"[bold green]Protocol Support ({label}):[/bold green]")
 
     for group_name, protocols in info["protocols"].items():
-        console.print(f"\n  [bold underline]{group_name}:[/bold underline]")
+        # Mark dialect-specific groups
+        if group_name in DIALECT_SPECIFIC_GROUPS:
+            console.print(f"\n  [bold underline]{group_name}:[/bold underline] [dim](dialect-specific)[/dim]")
+        else:
+            console.print(f"\n  [bold underline]{group_name}:[/bold underline]")
         for protocol_name, stats in protocols.items():
             pct = stats["percentage"]
             if pct == 100:
@@ -321,10 +403,18 @@ def _display_info_rich(info: Dict, verbose: int, version_display: str):
             )
 
             if verbose >= 2 and "methods" in stats:
-                for method, supported in stats["methods"].items():
-                    method_display = method.replace("supports_", "").replace("_", " ")
-                    m_status = "[green][OK][/green]" if supported else "[red][X][/red]"
-                    console.print(f"        {m_status} {method_display}")
+                for method, value in stats["methods"].items():
+                    method_display = method.replace("supports_", "").replace("_", " ").replace("is_", "").replace("_available", "")
+                    if isinstance(value, dict):
+                        # Method with parameters - show each arg's support
+                        console.print(f"        [dim]{method_display}:[/dim]")
+                        for arg, supported in value.get('args', {}).items():
+                            m_status = "[green][OK][/green]" if supported else "[red][X][/red]"
+                            console.print(f"            {m_status} {arg}")
+                    else:
+                        # No-arg method
+                        m_status = "[green][OK][/green]" if value else "[red][X][/red]"
+                        console.print(f"        {m_status} {method_display}")
 
     console.print()
 

--- a/src/rhosocial/activerecord/backend/impl/mysql/__main__.py
+++ b/src/rhosocial/activerecord/backend/impl/mysql/__main__.py
@@ -398,8 +398,32 @@ def main():
 
     if args.info:
         output_format = args.output if args.output != 'table' or RICH_AVAILABLE else 'json'
+
+        # Try to connect and get real version if database is provided
+        actual_version = args.version
+
+        if args.database:
+            try:
+                config = MySQLConnectionConfig(
+                    host=args.host, port=args.port, database=args.database,
+                    username=args.user, password=args.password, charset=args.charset,
+                )
+                backend = MySQLBackend(connection_config=config)
+                backend.connect()
+                backend.introspect_and_adapt()
+
+                # Get actual version
+                version_tuple = backend.get_server_version()
+                if version_tuple:
+                    actual_version = f"{version_tuple[0]}.{version_tuple[1]}.{version_tuple[2]}"
+
+                backend.disconnect()
+            except Exception as e:
+                logger.warning("Could not connect to database for introspection: %s", e)
+                # Fall back to command-line version or default
+
         display_info(verbose=args.verbose, output_format=output_format,
-                     version_str=args.version)
+                     version_str=actual_version)
         return
 
     numeric_level = getattr(logging, args.log_level.upper(), None)


### PR DESCRIPTION
## Description

This PR enhances the MySQL CLI with comprehensive protocol support information display and database introspection capabilities.

### Key Changes:

1. **Protocol Support Info Display** (`1c66e75`)
   - Add comprehensive protocol family groups for MySQL backend
   - Display detailed support information with `--info` flag
   - Include MySQL-specific protocols (Trigger, Table, Set, JSON, Spatial)

2. **Database Introspection for Version Detection** (`bf088cb`)
   - Connect to database and get actual server version when `--info` is used
   - Override CLI version argument with real detected version
   - Fall back to CLI version or default on connection failure

3. **Enhanced MySQL CLI Protocol Support Display** (`e4668f1`)
   - Add support for 'is_*_available' method pattern detection
   - Support parameterized methods (JSON functions, spatial types, explain formats)
   - Add MySQL-specific protocol group marker
   - Unify JSON output structure with 'database' and 'features' keys
   - Mark dialect-specific groups in rich display

## Type of change

- [x] `feat`: A new feature

## Breaking Change

- [ ] Yes
- [x] No

**Applicable `rhosocial-activerecord` Version Range:** >=1.0.0.dev8,<2.0.0

## Related Repositories/Packages

None - This change is specific to the MySQL backend CLI.

## Testing

- [x] All existing tests pass.
- [x] This change has been tested on MySQL 5.6, 5.7, 8.0, 8.4, 9.2, 9.6.

**Test Plan:**
- Ran full test suite: `PYTHONPATH=src .venv3.8/bin/pytest tests/ -v --tb=short`
- Result: 3168 passed, 199 skipped

## Checklist

- [x] My code follows the project's code style guidelines.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [x] I have checked for potential performance regressions.

## Commits

| Commit | Description |
|--------|-------------|
| `e4668f1` | feat: enhance MySQL CLI protocol support display |
| `bf088cb` | feat: add database introspection for version detection in MySQL CLI |
| `1c66e75` | feat: add protocol support info display to MySQL CLI |

## Files Changed

- `src/rhosocial/activerecord/backend/impl/mysql/__main__.py` (+413, -32)

## Additional Notes

This feature enhances the MySQL CLI's introspection capabilities, allowing users to see detailed protocol support information based on the actual database server version. This is particularly useful for developers who need to understand which features are available on their specific MySQL server version.
