### PR TITLE
feat(test): add Python version-aware fixture selection for MySQL

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,8 +51,8 @@ jobs:
 
     - name: Install activerecord and testsuite from git
       run: |
-        pip install rhosocial-activerecord==1.0.0.dev16
-        pip install rhosocial-activerecord-testsuite==1.0.0.dev6
+        pip install git+https://github.com/rhosocial/python-activerecord.git@release/v1.0.0.dev18
+        pip install git+https://github.com/rhosocial/python-activerecord-testsuite.git@release/v1.0.0.dev7
 
     - name: Create and test database
       run: |
@@ -145,8 +145,8 @@ jobs:
 
     - name: Install activerecord and testsuite from git
       run: |
-        pip install rhosocial-activerecord==1.0.0.dev16
-        pip install rhosocial-activerecord-testsuite==1.0.0.dev6
+        pip install git+https://github.com/rhosocial/python-activerecord.git@release/v1.0.0.dev18
+        pip install git+https://github.com/rhosocial/python-activerecord-testsuite.git@release/v1.0.0.dev7
 
     - name: Create and test database
       run: |
@@ -238,8 +238,8 @@ jobs:
 
     - name: Install activerecord and testsuite from git
       run: |
-        pip install rhosocial-activerecord==1.0.0.dev16
-        pip install rhosocial-activerecord-testsuite==1.0.0.dev6
+        pip install git+https://github.com/rhosocial/python-activerecord.git@release/v1.0.0.dev18
+        pip install git+https://github.com/rhosocial/python-activerecord-testsuite.git@release/v1.0.0.dev7
 
     - name: Create and test database
       run: |
@@ -331,8 +331,8 @@ jobs:
 
     - name: Install activerecord and testsuite from git
       run: |
-        pip install rhosocial-activerecord==1.0.0.dev16
-        pip install rhosocial-activerecord-testsuite==1.0.0.dev6
+        pip install git+https://github.com/rhosocial/python-activerecord.git@release/v1.0.0.dev18
+        pip install git+https://github.com/rhosocial/python-activerecord-testsuite.git@release/v1.0.0.dev7
 
     - name: Create and test database
       run: |
@@ -424,8 +424,8 @@ jobs:
 
     - name: Install activerecord and testsuite from git
       run: |
-        pip install rhosocial-activerecord==1.0.0.dev16
-        pip install rhosocial-activerecord-testsuite==1.0.0.dev6
+        pip install git+https://github.com/rhosocial/python-activerecord.git@release/v1.0.0.dev18
+        pip install git+https://github.com/rhosocial/python-activerecord-testsuite.git@release/v1.0.0.dev7
 
     - name: Create and test database
       run: |
@@ -517,8 +517,8 @@ jobs:
 
     - name: Install activerecord and testsuite from git
       run: |
-        pip install rhosocial-activerecord==1.0.0.dev16
-        pip install rhosocial-activerecord-testsuite==1.0.0.dev6
+        pip install git+https://github.com/rhosocial/python-activerecord.git@release/v1.0.0.dev18
+        pip install git+https://github.com/rhosocial/python-activerecord-testsuite.git@release/v1.0.0.dev7
 
     - name: Create and test database
       run: |
@@ -611,8 +611,8 @@ jobs:
 
     - name: Install activerecord and testsuite from git
       run: |
-        pip install rhosocial-activerecord==1.0.0.dev16
-        pip install rhosocial-activerecord-testsuite==1.0.0.dev6
+        pip install git+https://github.com/rhosocial/python-activerecord.git@release/v1.0.0.dev18
+        pip install git+https://github.com/rhosocial/python-activerecord-testsuite.git@release/v1.0.0.dev7
 
     - name: Create test database
       run: |
@@ -729,8 +729,8 @@ jobs:
 
     - name: Install activerecord and testsuite from git
       run: |
-        pip install rhosocial-activerecord==1.0.0.dev16
-        pip install rhosocial-activerecord-testsuite==1.0.0.dev6
+        pip install git+https://github.com/rhosocial/python-activerecord.git@release/v1.0.0.dev18
+        pip install git+https://github.com/rhosocial/python-activerecord-testsuite.git@release/v1.0.0.dev7
 
     - name: Create and test database
       run: |
@@ -822,8 +822,8 @@ jobs:
 
     - name: Install activerecord and testsuite from git
       run: |
-        pip install rhosocial-activerecord==1.0.0.dev16
-        pip install rhosocial-activerecord-testsuite==1.0.0.dev6
+        pip install git+https://github.com/rhosocial/python-activerecord.git@release/v1.0.0.dev18
+        pip install git+https://github.com/rhosocial/python-activerecord-testsuite.git@release/v1.0.0.dev7
 
     - name: Create and test database
       run: |
@@ -915,8 +915,8 @@ jobs:
 
     - name: Install activerecord and testsuite from git
       run: |
-        pip install rhosocial-activerecord==1.0.0.dev16
-        pip install rhosocial-activerecord-testsuite==1.0.0.dev6
+        pip install git+https://github.com/rhosocial/python-activerecord.git@release/v1.0.0.dev18
+        pip install git+https://github.com/rhosocial/python-activerecord-testsuite.git@release/v1.0.0.dev7
 
     - name: Create and test database
       run: |
@@ -1008,8 +1008,8 @@ jobs:
 
     - name: Install activerecord and testsuite from git
       run: |
-        pip install rhosocial-activerecord==1.0.0.dev16
-        pip install rhosocial-activerecord-testsuite==1.0.0.dev6
+        pip install git+https://github.com/rhosocial/python-activerecord.git@release/v1.0.0.dev18
+        pip install git+https://github.com/rhosocial/python-activerecord-testsuite.git@release/v1.0.0.dev7
 
     - name: Create and test database
       run: |

--- a/changelog.d/13.feat.md
+++ b/changelog.d/13.feat.md
@@ -1,0 +1,1 @@
+Added Python version-aware fixture selection for MySQL backend testing, enabling Python 3.10+ UnionType syntax support.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,8 +109,8 @@ multi_line_output = 3
 line_length = 100
 
 [tool.ruff]
-line-length = 100
-target-version = "py314"
+line-length = 120
+target-version = "py38"
 select = ["E", "F", "B"]
 ignore = []
 

--- a/src/rhosocial/activerecord/backend/impl/mysql/async_backend.py
+++ b/src/rhosocial/activerecord/backend/impl/mysql/async_backend.py
@@ -28,8 +28,8 @@ from rhosocial.activerecord.backend.errors import (
     IntegrityError,
     OperationalError,
     QueryError,
-    ReturningNotSupportedError,
 )
+from rhosocial.activerecord.backend.dialect.exceptions import UnsupportedFeatureError
 from rhosocial.activerecord.backend.type_adapter import SQLTypeAdapter
 from rhosocial.activerecord.backend.result import QueryResult
 from .adapters import (
@@ -343,8 +343,10 @@ class AsyncMySQLBackend(AsyncStorageBackend):
         if self.dialect.supports_returning_clause():
             return True
         else:
-            raise ReturningNotSupportedError(
-                "RETURNING clause is not supported by MySQL. "
+            raise UnsupportedFeatureError(
+                self.name,
+                "RETURNING clause",
+                "MySQL does not support RETURNING clause. "
                 "Consider using LAST_INSERT_ID() or alternative approaches."
             )
 

--- a/src/rhosocial/activerecord/backend/impl/mysql/backend.py
+++ b/src/rhosocial/activerecord/backend/impl/mysql/backend.py
@@ -30,8 +30,8 @@ from rhosocial.activerecord.backend.errors import (
     IntegrityError,
     OperationalError,
     QueryError,
-    ReturningNotSupportedError,
 )
+from rhosocial.activerecord.backend.dialect.exceptions import UnsupportedFeatureError
 from rhosocial.activerecord.backend.type_adapter import SQLTypeAdapter
 from rhosocial.activerecord.backend.result import QueryResult
 from rhosocial.activerecord.backend.config import ConnectionConfig
@@ -345,8 +345,10 @@ class MySQLBackend(StorageBackend):
         if self.dialect.supports_returning_clause():
             return True
         else:
-            raise ReturningNotSupportedError(
-                "RETURNING clause is not supported by MySQL. "
+            raise UnsupportedFeatureError(
+                self.name,
+                "RETURNING clause",
+                "MySQL does not support RETURNING clause. "
                 "Consider using LAST_INSERT_ID() or alternative approaches."
             )
 

--- a/tests/providers/basic.py
+++ b/tests/providers/basic.py
@@ -11,6 +11,7 @@ Its main responsibilities are:
 3.  Cleaning up any resources after a test runs.
 """
 import os
+import sys
 import logging
 from typing import Type, List, Tuple, Optional
 
@@ -18,17 +19,148 @@ logger = logging.getLogger(__name__)
 
 from rhosocial.activerecord.backend.type_adapter import BaseSQLTypeAdapter
 from rhosocial.activerecord.model import ActiveRecord
-# The models are defined generically in the testsuite...
+
+# Import the fixture selector utility
+from rhosocial.activerecord.testsuite.utils import select_fixture
+
+# Import base version models (Python 3.8+)
 from rhosocial.activerecord.testsuite.feature.basic.fixtures.models import (
-    User, TypeCase, ValidatedFieldUser, TypeTestModel, ValidatedUser, TypeAdapterTest, YesOrNoBooleanAdapter,
-    MappedUser, MappedPost, MappedComment, ColumnMappingModel, MixedAnnotationModel
+    User as UserBase, TypeCase as TypeCaseBase, ValidatedFieldUser as ValidatedFieldUserBase,
+    TypeTestModel as TypeTestModelBase, ValidatedUser as ValidatedUserBase,
+    TypeAdapterTest as TypeAdapterTestBase, YesOrNoBooleanAdapter,
+    MappedUser as MappedUserBase, MappedPost as MappedPostBase, MappedComment as MappedCommentBase,
+    ColumnMappingModel as ColumnMappingModelBase, MixedAnnotationModel as MixedAnnotationModelBase
 )
-# Import async models
+# Import async base models
 from rhosocial.activerecord.testsuite.feature.basic.fixtures.models import (
-    AsyncUser, AsyncTypeCase, AsyncValidatedUser, AsyncValidatedFieldUser, AsyncTypeTestModel,
-    AsyncTypeAdapterTest, AsyncMappedUser, AsyncMappedPost, AsyncMappedComment,
-    AsyncColumnMappingModel, AsyncMixedAnnotationModel
+    AsyncUser as AsyncUserBase, AsyncTypeCase as AsyncTypeCaseBase,
+    AsyncValidatedUser as AsyncValidatedUserBase, AsyncValidatedFieldUser as AsyncValidatedFieldUserBase,
+    AsyncTypeTestModel as AsyncTypeTestModelBase, AsyncTypeAdapterTest as AsyncTypeAdapterTestBase,
+    AsyncMappedUser as AsyncMappedUserBase, AsyncMappedPost as AsyncMappedPostBase,
+    AsyncMappedComment as AsyncMappedCommentBase,
+    AsyncColumnMappingModel as AsyncColumnMappingModelBase, AsyncMixedAnnotationModel as AsyncMixedAnnotationModelBase
 )
+
+# Conditionally import Python 3.10+ models
+User310 = TypeCase310 = ValidatedFieldUser310 = TypeTestModel310 = ValidatedUser310 = None
+TypeAdapterTest310 = MappedUser310 = MappedPost310 = MappedComment310 = None
+ColumnMappingModel310 = MixedAnnotationModel310 = None
+AsyncUser310 = AsyncTypeCase310 = AsyncValidatedFieldUser310 = AsyncTypeTestModel310 = None
+AsyncValidatedUser310 = AsyncTypeAdapterTest310 = AsyncMappedUser310 = AsyncMappedPost310 = None
+AsyncMappedComment310 = AsyncColumnMappingModel310 = AsyncMixedAnnotationModel310 = None
+
+if sys.version_info >= (3, 10):
+    try:
+        from rhosocial.activerecord.testsuite.feature.basic.fixtures.models_py310 import (
+            User as User310, TypeCase as TypeCase310, ValidatedFieldUser as ValidatedFieldUser310,
+            TypeTestModel as TypeTestModel310, ValidatedUser as ValidatedUser310,
+            TypeAdapterTest as TypeAdapterTest310,
+            MappedUser as MappedUser310, MappedPost as MappedPost310, MappedComment as MappedComment310,
+            ColumnMappingModel as ColumnMappingModel310, MixedAnnotationModel as MixedAnnotationModel310
+        )
+        from rhosocial.activerecord.testsuite.feature.basic.fixtures.models_py310 import (
+            AsyncUser as AsyncUser310, AsyncTypeCase as AsyncTypeCase310,
+            AsyncValidatedUser as AsyncValidatedUser310, AsyncValidatedFieldUser as AsyncValidatedFieldUser310,
+            AsyncTypeTestModel as AsyncTypeTestModel310, AsyncTypeAdapterTest as AsyncTypeAdapterTest310,
+            AsyncMappedUser as AsyncMappedUser310, AsyncMappedPost as AsyncMappedPost310,
+            AsyncMappedComment as AsyncMappedComment310,
+            AsyncColumnMappingModel as AsyncColumnMappingModel310, AsyncMixedAnnotationModel as AsyncMixedAnnotationModel310
+        )
+    except ImportError as e:
+        logger.warning(f"Failed to import Python 3.10+ fixtures: {e}")
+
+# Conditionally import Python 3.11+ models
+User311 = TypeCase311 = ValidatedFieldUser311 = TypeTestModel311 = ValidatedUser311 = None
+TypeAdapterTest311 = MappedUser311 = MappedPost311 = MappedComment311 = None
+ColumnMappingModel311 = MixedAnnotationModel311 = None
+AsyncUser311 = AsyncTypeCase311 = AsyncValidatedFieldUser311 = AsyncTypeTestModel311 = None
+AsyncValidatedUser311 = AsyncTypeAdapterTest311 = AsyncMappedUser311 = AsyncMappedPost311 = None
+AsyncMappedComment311 = AsyncColumnMappingModel311 = AsyncMixedAnnotationModel311 = None
+
+if sys.version_info >= (3, 11):
+    try:
+        from rhosocial.activerecord.testsuite.feature.basic.fixtures.models_py311 import (
+            User as User311, TypeCase as TypeCase311, ValidatedFieldUser as ValidatedFieldUser311,
+            TypeTestModel as TypeTestModel311, ValidatedUser as ValidatedUser311,
+            TypeAdapterTest as TypeAdapterTest311,
+            MappedUser as MappedUser311, MappedPost as MappedPost311, MappedComment as MappedComment311,
+            ColumnMappingModel as ColumnMappingModel311, MixedAnnotationModel as MixedAnnotationModel311
+        )
+        from rhosocial.activerecord.testsuite.feature.basic.fixtures.models_py311 import (
+            AsyncUser as AsyncUser311, AsyncTypeCase as AsyncTypeCase311,
+            AsyncValidatedUser as AsyncValidatedUser311, AsyncValidatedFieldUser as AsyncValidatedFieldUser311,
+            AsyncTypeTestModel as AsyncTypeTestModel311, AsyncTypeAdapterTest as AsyncTypeAdapterTest311,
+            AsyncMappedUser as AsyncMappedUser311, AsyncMappedPost as AsyncMappedPost311,
+            AsyncMappedComment as AsyncMappedComment311,
+            AsyncColumnMappingModel as AsyncColumnMappingModel311, AsyncMixedAnnotationModel as AsyncMixedAnnotationModel311
+        )
+    except ImportError as e:
+        logger.warning(f"Failed to import Python 3.11+ fixtures: {e}")
+
+# Conditionally import Python 3.12+ models
+User312 = TypeCase312 = ValidatedFieldUser312 = TypeTestModel312 = ValidatedUser312 = None
+TypeAdapterTest312 = MappedUser312 = MappedPost312 = MappedComment312 = None
+ColumnMappingModel312 = MixedAnnotationModel312 = None
+AsyncUser312 = AsyncTypeCase312 = AsyncValidatedFieldUser312 = AsyncTypeTestModel312 = None
+AsyncValidatedUser312 = AsyncTypeAdapterTest312 = AsyncMappedUser312 = AsyncMappedPost312 = None
+AsyncMappedComment312 = AsyncColumnMappingModel312 = AsyncMixedAnnotationModel312 = None
+
+if sys.version_info >= (3, 12):
+    try:
+        from rhosocial.activerecord.testsuite.feature.basic.fixtures.models_py312 import (
+            User as User312, TypeCase as TypeCase312, ValidatedFieldUser as ValidatedFieldUser312,
+            TypeTestModel as TypeTestModel312, ValidatedUser as ValidatedUser312,
+            TypeAdapterTest as TypeAdapterTest312,
+            MappedUser as MappedUser312, MappedPost as MappedPost312, MappedComment as MappedComment312,
+            ColumnMappingModel as ColumnMappingModel312, MixedAnnotationModel as MixedAnnotationModel312
+        )
+        from rhosocial.activerecord.testsuite.feature.basic.fixtures.models_py312 import (
+            AsyncUser as AsyncUser312, AsyncTypeCase as AsyncTypeCase312,
+            AsyncValidatedUser as AsyncValidatedUser312, AsyncValidatedFieldUser as AsyncValidatedFieldUser312,
+            AsyncTypeTestModel as AsyncTypeTestModel312, AsyncTypeAdapterTest as AsyncTypeAdapterTest312,
+            AsyncMappedUser as AsyncMappedUser312, AsyncMappedPost as AsyncMappedPost312,
+            AsyncMappedComment as AsyncMappedComment312,
+            AsyncColumnMappingModel as AsyncColumnMappingModel312, AsyncMixedAnnotationModel as AsyncMixedAnnotationModel312
+        )
+    except ImportError as e:
+        logger.warning(f"Failed to import Python 3.12+ fixtures: {e}")
+
+
+# Select appropriate fixture classes based on Python version
+def _select_model_class(base_cls, py312_cls, py311_cls, py310_cls, model_name: str) -> Type:
+    """Select the most appropriate model class for the current Python version."""
+    candidates = [c for c in [py312_cls, py311_cls, py310_cls, base_cls] if c is not None]
+    selected = select_fixture(*candidates)
+    logger.info(f"Selected {model_name}: {selected.__name__} from {selected.__module__}")
+    return selected
+
+
+# Select sync models
+User = _select_model_class(UserBase, User312, User311, User310, "User")
+TypeCase = _select_model_class(TypeCaseBase, TypeCase312, TypeCase311, TypeCase310, "TypeCase")
+ValidatedFieldUser = _select_model_class(ValidatedFieldUserBase, ValidatedFieldUser312, ValidatedFieldUser311, ValidatedFieldUser310, "ValidatedFieldUser")
+TypeTestModel = _select_model_class(TypeTestModelBase, TypeTestModel312, TypeTestModel311, TypeTestModel310, "TypeTestModel")
+ValidatedUser = _select_model_class(ValidatedUserBase, ValidatedUser312, ValidatedUser311, ValidatedUser310, "ValidatedUser")
+TypeAdapterTest = _select_model_class(TypeAdapterTestBase, TypeAdapterTest312, TypeAdapterTest311, TypeAdapterTest310, "TypeAdapterTest")
+MappedUser = _select_model_class(MappedUserBase, MappedUser312, MappedUser311, MappedUser310, "MappedUser")
+MappedPost = _select_model_class(MappedPostBase, MappedPost312, MappedPost311, MappedPost310, "MappedPost")
+MappedComment = _select_model_class(MappedCommentBase, MappedComment312, MappedComment311, MappedComment310, "MappedComment")
+ColumnMappingModel = _select_model_class(ColumnMappingModelBase, ColumnMappingModel312, ColumnMappingModel311, ColumnMappingModel310, "ColumnMappingModel")
+MixedAnnotationModel = _select_model_class(MixedAnnotationModelBase, MixedAnnotationModel312, MixedAnnotationModel311, MixedAnnotationModel310, "MixedAnnotationModel")
+
+# Select async models
+AsyncUser = _select_model_class(AsyncUserBase, AsyncUser312, AsyncUser311, AsyncUser310, "AsyncUser")
+AsyncTypeCase = _select_model_class(AsyncTypeCaseBase, AsyncTypeCase312, AsyncTypeCase311, AsyncTypeCase310, "AsyncTypeCase")
+AsyncValidatedFieldUser = _select_model_class(AsyncValidatedFieldUserBase, AsyncValidatedFieldUser312, AsyncValidatedFieldUser311, AsyncValidatedFieldUser310, "AsyncValidatedFieldUser")
+AsyncTypeTestModel = _select_model_class(AsyncTypeTestModelBase, AsyncTypeTestModel312, AsyncTypeTestModel311, AsyncTypeTestModel310, "AsyncTypeTestModel")
+AsyncValidatedUser = _select_model_class(AsyncValidatedUserBase, AsyncValidatedUser312, AsyncValidatedUser311, AsyncValidatedUser310, "AsyncValidatedUser")
+AsyncTypeAdapterTest = _select_model_class(AsyncTypeAdapterTestBase, AsyncTypeAdapterTest312, AsyncTypeAdapterTest311, AsyncTypeAdapterTest310, "AsyncTypeAdapterTest")
+AsyncMappedUser = _select_model_class(AsyncMappedUserBase, AsyncMappedUser312, AsyncMappedUser311, AsyncMappedUser310, "AsyncMappedUser")
+AsyncMappedPost = _select_model_class(AsyncMappedPostBase, AsyncMappedPost312, AsyncMappedPost311, AsyncMappedPost310, "AsyncMappedPost")
+AsyncMappedComment = _select_model_class(AsyncMappedCommentBase, AsyncMappedComment312, AsyncMappedComment311, AsyncMappedComment310, "AsyncMappedComment")
+AsyncColumnMappingModel = _select_model_class(AsyncColumnMappingModelBase, AsyncColumnMappingModel312, AsyncColumnMappingModel311, AsyncColumnMappingModel310, "AsyncColumnMappingModel")
+AsyncMixedAnnotationModel = _select_model_class(AsyncMixedAnnotationModelBase, AsyncMixedAnnotationModel312, AsyncMixedAnnotationModel311, AsyncMixedAnnotationModel310, "AsyncMixedAnnotationModel")
+
 from rhosocial.activerecord.testsuite.feature.basic.interfaces import IBasicProvider
 # ...and the scenarios are defined specifically for this backend.
 from .scenarios import get_enabled_scenarios, get_scenario
@@ -298,7 +430,7 @@ class BasicProvider(IBasicProvider):
     async def cleanup_after_test_async(self, scenario_name: str):
         """
         Performs async cleanup after a test, dropping all tables and disconnecting backends.
-        
+
         Fix for mysql-connector-python bug: "RuntimeError: Set changed size during iteration"
         The issue is that conn.close() iterates over _cursors WeakSet while cursor.close()
         modifies it. We fix this by manually closing cursors BEFORE calling disconnect().
@@ -331,19 +463,19 @@ class BasicProvider(IBasicProvider):
     async def _safe_async_disconnect(self, backend_instance):
         """
         Safely disconnect an async MySQL backend, avoiding the "Set changed size during iteration" bug.
-        
+
         The bug occurs because:
         1. backend._connection is a mysql.connector.aio connection
         2. connection._cursors is a WeakSet
         3. connection.close() iterates over _cursors while cursor.close() modifies it
         4. Result: RuntimeError
-        
+
         Fix: Close all cursors manually BEFORE calling connection.close()
         """
         connection = backend_instance._connection
         if connection is None:
             return
-        
+
         # Step 1: Close all cursors manually (while event loop is still alive!)
         cursors = list(connection._cursors)
         for cursor in cursors:
@@ -352,12 +484,12 @@ class BasicProvider(IBasicProvider):
             except Exception as e:
                 logger.warning(f"Error closing cursor during cleanup: {type(e).__name__}: {e}")
         # Now _cursors should be empty
-        
+
         # Step 2: Now safe to close connection
         # The iteration in connection.close() will find an empty set
         try:
             await connection.close()
         except Exception as e:
             logger.warning(f"Error closing connection during cleanup: {type(e).__name__}: {e}")
-        
+
         backend_instance._connection = None

--- a/tests/providers/events.py
+++ b/tests/providers/events.py
@@ -11,11 +11,75 @@ Its main responsibilities are:
 3.  Cleaning up any resources (like temporary database files) after a test runs.
 """
 import os
+import sys
+import logging
 from typing import Type, List
+
 from rhosocial.activerecord.model import ActiveRecord
+
+# Setup logging for fixture selection debugging
+logger = logging.getLogger(__name__)
+
+# Import the fixture selector utility
+from rhosocial.activerecord.testsuite.utils import select_fixture
+
+# Import base version models (Python 3.8+)
+from rhosocial.activerecord.testsuite.feature.events.fixtures.models import (
+    EventTestModel as EventTestModelBase,
+    EventTrackingModel as EventTrackingModelBase
+)
+
+# Conditionally import Python 3.10+ models
+EventTestModel310 = EventTrackingModel310 = None
+
+if sys.version_info >= (3, 10):
+    try:
+        from rhosocial.activerecord.testsuite.feature.events.fixtures.models_py310 import (
+            EventTestModel as EventTestModel310,
+            EventTrackingModel as EventTrackingModel310
+        )
+    except ImportError as e:
+        logger.warning(f"Failed to import Python 3.10+ fixtures: {e}")
+
+# Conditionally import Python 3.11+ models
+EventTestModel311 = EventTrackingModel311 = None
+
+if sys.version_info >= (3, 11):
+    try:
+        from rhosocial.activerecord.testsuite.feature.events.fixtures.models_py311 import (
+            EventTestModel as EventTestModel311,
+            EventTrackingModel as EventTrackingModel311
+        )
+    except ImportError as e:
+        logger.warning(f"Failed to import Python 3.11+ fixtures: {e}")
+
+# Conditionally import Python 3.12+ models
+EventTestModel312 = EventTrackingModel312 = None
+
+if sys.version_info >= (3, 12):
+    try:
+        from rhosocial.activerecord.testsuite.feature.events.fixtures.models_py312 import (
+            EventTestModel as EventTestModel312,
+            EventTrackingModel as EventTrackingModel312
+        )
+    except ImportError as e:
+        logger.warning(f"Failed to import Python 3.12+ fixtures: {e}")
+
+
+# Select appropriate fixture classes based on Python version
+def _select_model_class(base_cls, py312_cls, py311_cls, py310_cls, model_name: str) -> Type:
+    """Select the most appropriate model class for the current Python version."""
+    candidates = [c for c in [py312_cls, py311_cls, py310_cls, base_cls] if c is not None]
+    selected = select_fixture(*candidates)
+    logger.info(f"Selected {model_name}: {selected.__name__} from {selected.__module__}")
+    return selected
+
+
+# Select models
+EventTestModel = _select_model_class(EventTestModelBase, EventTestModel312, EventTestModel311, EventTestModel310, "EventTestModel")
+EventTrackingModel = _select_model_class(EventTrackingModelBase, EventTrackingModel312, EventTrackingModel311, EventTrackingModel310, "EventTrackingModel")
+
 from rhosocial.activerecord.testsuite.feature.events.interfaces import IEventsProvider
-# The models are defined generically in the testsuite...
-from rhosocial.activerecord.testsuite.feature.events.fixtures.models import EventTestModel, EventTrackingModel
 # ...and the scenarios are defined specifically for this backend.
 from .scenarios import get_enabled_scenarios, get_scenario
 

--- a/tests/providers/mixins.py
+++ b/tests/providers/mixins.py
@@ -11,11 +11,85 @@ Its main responsibilities are:
 3.  Cleaning up any resources (like temporary database files) after a test runs.
 """
 import os
+import sys
+import logging
 from typing import Type, List
+
 from rhosocial.activerecord.model import ActiveRecord
+
+# Setup logging for fixture selection debugging
+logger = logging.getLogger(__name__)
+
+# Import the fixture selector utility
+from rhosocial.activerecord.testsuite.utils import select_fixture
+
+# Import base version models (Python 3.8+)
+from rhosocial.activerecord.testsuite.feature.mixins.fixtures.models import (
+    TimestampedPost as TimestampedPostBase,
+    VersionedProduct as VersionedProductBase,
+    Task as TaskBase,
+    CombinedArticle as CombinedArticleBase
+)
+
+# Conditionally import Python 3.10+ models
+TimestampedPost310 = VersionedProduct310 = Task310 = CombinedArticle310 = None
+
+if sys.version_info >= (3, 10):
+    try:
+        from rhosocial.activerecord.testsuite.feature.mixins.fixtures.models_py310 import (
+            TimestampedPost as TimestampedPost310,
+            VersionedProduct as VersionedProduct310,
+            Task as Task310,
+            CombinedArticle as CombinedArticle310
+        )
+    except ImportError as e:
+        logger.warning(f"Failed to import Python 3.10+ fixtures: {e}")
+
+# Conditionally import Python 3.11+ models
+TimestampedPost311 = VersionedProduct311 = Task311 = CombinedArticle311 = None
+
+if sys.version_info >= (3, 11):
+    try:
+        from rhosocial.activerecord.testsuite.feature.mixins.fixtures.models_py311 import (
+            TimestampedPost as TimestampedPost311,
+            VersionedProduct as VersionedProduct311,
+            Task as Task311,
+            CombinedArticle as CombinedArticle311
+        )
+    except ImportError as e:
+        logger.warning(f"Failed to import Python 3.11+ fixtures: {e}")
+
+# Conditionally import Python 3.12+ models
+TimestampedPost312 = VersionedProduct312 = Task312 = CombinedArticle312 = None
+
+if sys.version_info >= (3, 12):
+    try:
+        from rhosocial.activerecord.testsuite.feature.mixins.fixtures.models_py312 import (
+            TimestampedPost as TimestampedPost312,
+            VersionedProduct as VersionedProduct312,
+            Task as Task312,
+            CombinedArticle as CombinedArticle312
+        )
+    except ImportError as e:
+        logger.warning(f"Failed to import Python 3.12+ fixtures: {e}")
+
+
+# Select appropriate fixture classes based on Python version
+def _select_model_class(base_cls, py312_cls, py311_cls, py310_cls, model_name: str) -> Type:
+    """Select the most appropriate model class for the current Python version."""
+    candidates = [c for c in [py312_cls, py311_cls, py310_cls, base_cls] if c is not None]
+    selected = select_fixture(*candidates)
+    logger.info(f"Selected {model_name}: {selected.__name__} from {selected.__module__}")
+    return selected
+
+
+# Select models
+TimestampedPost = _select_model_class(TimestampedPostBase, TimestampedPost312, TimestampedPost311, TimestampedPost310, "TimestampedPost")
+VersionedProduct = _select_model_class(VersionedProductBase, VersionedProduct312, VersionedProduct311, VersionedProduct310, "VersionedProduct")
+Task = _select_model_class(TaskBase, Task312, Task311, Task310, "Task")
+CombinedArticle = _select_model_class(CombinedArticleBase, CombinedArticle312, CombinedArticle311, CombinedArticle310, "CombinedArticle")
+
 from rhosocial.activerecord.testsuite.feature.mixins.interfaces import IMixinsProvider
-# The models are defined generically in the testsuite...
-from rhosocial.activerecord.testsuite.feature.mixins.fixtures.models import TimestampedPost, VersionedProduct, Task, CombinedArticle
 # ...and the scenarios are defined specifically for this backend.
 from .scenarios import get_enabled_scenarios, get_scenario
 

--- a/tests/providers/query.py
+++ b/tests/providers/query.py
@@ -11,13 +11,95 @@ Its main responsibilities are:
 3.  Cleaning up any resources (like temporary database files) after a test runs.
 """
 import os
+import sys
+import logging
 from typing import Type, List, Tuple
+
 from rhosocial.activerecord.model import ActiveRecord
-from rhosocial.activerecord.testsuite.feature.query.interfaces import IQueryProvider
-# The models are defined generically in the testsuite...
-from rhosocial.activerecord.testsuite.feature.query.fixtures.models import User, Order, OrderItem, Post, Comment, MappedUser, MappedPost, MappedComment
+
+# Setup logging for fixture selection debugging
+logger = logging.getLogger(__name__)
+
+# Import the fixture selector utility
+from rhosocial.activerecord.testsuite.utils import select_fixture
+
+# Import base version models (Python 3.8+)
+from rhosocial.activerecord.testsuite.feature.query.fixtures.models import (
+    User as UserBase, JsonUser as JsonUserBase,
+    Order as OrderBase, OrderItem as OrderItemBase,
+    Post as PostBase, Comment as CommentBase,
+    MappedUser as MappedUserBase, MappedPost as MappedPostBase, MappedComment as MappedCommentBase
+)
 from rhosocial.activerecord.testsuite.feature.query.fixtures.cte_models import Node
 from rhosocial.activerecord.testsuite.feature.query.fixtures.extended_models import ExtendedOrder, ExtendedOrderItem
+
+# Conditionally import Python 3.10+ models
+User310 = JsonUser310 = Order310 = OrderItem310 = Post310 = Comment310 = None
+MappedUser310 = MappedPost310 = MappedComment310 = None
+
+if sys.version_info >= (3, 10):
+    try:
+        from rhosocial.activerecord.testsuite.feature.query.fixtures.models_py310 import (
+            User as User310, JsonUser as JsonUser310,
+            Order as Order310, OrderItem as OrderItem310,
+            Post as Post310, Comment as Comment310,
+            MappedUser as MappedUser310, MappedPost as MappedPost310, MappedComment as MappedComment310
+        )
+    except ImportError as e:
+        logger.warning(f"Failed to import Python 3.10+ fixtures: {e}")
+
+# Conditionally import Python 3.11+ models
+User311 = JsonUser311 = Order311 = OrderItem311 = Post311 = Comment311 = None
+MappedUser311 = MappedPost311 = MappedComment311 = None
+
+if sys.version_info >= (3, 11):
+    try:
+        from rhosocial.activerecord.testsuite.feature.query.fixtures.models_py311 import (
+            User as User311, JsonUser as JsonUser311,
+            Order as Order311, OrderItem as OrderItem311,
+            Post as Post311, Comment as Comment311,
+            MappedUser as MappedUser311, MappedPost as MappedPost311, MappedComment as MappedComment311
+        )
+    except ImportError as e:
+        logger.warning(f"Failed to import Python 3.11+ fixtures: {e}")
+
+# Conditionally import Python 3.12+ models
+User312 = JsonUser312 = Order312 = OrderItem312 = Post312 = Comment312 = None
+MappedUser312 = MappedPost312 = MappedComment312 = None
+
+if sys.version_info >= (3, 12):
+    try:
+        from rhosocial.activerecord.testsuite.feature.query.fixtures.models_py312 import (
+            User as User312, JsonUser as JsonUser312,
+            Order as Order312, OrderItem as OrderItem312,
+            Post as Post312, Comment as Comment312,
+            MappedUser as MappedUser312, MappedPost as MappedPost312, MappedComment as MappedComment312
+        )
+    except ImportError as e:
+        logger.warning(f"Failed to import Python 3.12+ fixtures: {e}")
+
+
+# Select appropriate fixture classes based on Python version
+def _select_model_class(base_cls, py312_cls, py311_cls, py310_cls, model_name: str) -> Type:
+    """Select the most appropriate model class for the current Python version."""
+    candidates = [c for c in [py312_cls, py311_cls, py310_cls, base_cls] if c is not None]
+    selected = select_fixture(*candidates)
+    logger.info(f"Selected {model_name}: {selected.__name__} from {selected.__module__}")
+    return selected
+
+
+# Select sync models
+User = _select_model_class(UserBase, User312, User311, User310, "User")
+JsonUser = _select_model_class(JsonUserBase, JsonUser312, JsonUser311, JsonUser310, "JsonUser")
+Order = _select_model_class(OrderBase, Order312, Order311, Order310, "Order")
+OrderItem = _select_model_class(OrderItemBase, OrderItem312, OrderItem311, OrderItem310, "OrderItem")
+Post = _select_model_class(PostBase, Post312, Post311, Post310, "Post")
+Comment = _select_model_class(CommentBase, Comment312, Comment311, Comment310, "Comment")
+MappedUser = _select_model_class(MappedUserBase, MappedUser312, MappedUser311, MappedUser310, "MappedUser")
+MappedPost = _select_model_class(MappedPostBase, MappedPost312, MappedPost311, MappedPost310, "MappedPost")
+MappedComment = _select_model_class(MappedCommentBase, MappedComment312, MappedComment311, MappedComment310, "MappedComment")
+
+from rhosocial.activerecord.testsuite.feature.query.interfaces import IQueryProvider
 # ...and the scenarios are defined specifically for this backend.
 from .scenarios import get_enabled_scenarios, get_scenario
 
@@ -139,7 +221,6 @@ class QueryProvider(IQueryProvider):
     def setup_json_user_fixtures(self, scenario_name: str) -> Tuple[Type[ActiveRecord], ...]:
         """Sets up the database for the JSON user model tests."""
         import pytest
-        from rhosocial.activerecord.testsuite.feature.query.fixtures.models import JsonUser
         backend_class, config = get_scenario(scenario_name)
         JsonUser.configure(config, backend_class)
         backend_instance = JsonUser.__backend__


### PR DESCRIPTION
## Description

This PR adds Python version-aware fixture selection for MySQL backend testing, enabling the use of Python 3.10+ UnionType syntax (X | Y) for model field type annotations.

### Changes
- feat(test): add Python version-aware fixture selection for MySQL
- feat(test): integrate fixture selection pattern for MySQL providers
- chore(ci): update activerecord dependency to release/v1.0.0.dev18

## Type of change

- [x] `feat`: A new feature
- [x] `test`: Adding missing tests or correcting existing tests
- [x] `chore`: Changes to the build process or auxiliary tools

## Breaking Change

- [ ] Yes
- [x] No

**Applicable `rhosocial-activerecord` Version Range:** >=1.0.0.dev18

## Related Repositories/Packages

- `python-activerecord`: Core package with environment-aware fixture selection support
- `python-activerecord-testsuite`: Shared test suite with fixture selection utilities

## Testing

- [x] All existing tests pass.
- [x] This change has been tested on MySQL 5.6-9.6 with Python 3.8-3.14.

**Test Plan:**
CI/CD pipeline will run tests across all MySQL and Python version combinations.

## Checklist

- [x] My code follows the project's code style guidelines.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings.
- [x] I have added a Changelog fragment.

## Additional Notes

This PR depends on the corresponding changes in `python-activerecord` (PR #43) and `python-activerecord-testsuite`.
