### PR TITLE
feat(backend): add MySQL SET/VECTOR type support and refactor to mixins

### DIFF
--- a/src/rhosocial/activerecord/backend/impl/mysql/adapters.py
+++ b/src/rhosocial/activerecord/backend/impl/mysql/adapters.py
@@ -453,6 +453,60 @@ class MySQLSetAdapter(SQLTypeAdapter):
         sorted_values = sorted(str(v) for v in value)
         return ','.join(sorted_values) if sorted_values else ''
 
+    def _decode_set_from_int(
+        self,
+        value: int,
+        target_type: Type,
+        allowed_values: Optional[List[str]]
+    ) -> Union[set, frozenset]:
+        """
+        Decode MySQL SET from integer bit flags.
+
+        Args:
+            value: Integer bit flags
+            target_type: Target Python type (set or frozenset)
+            allowed_values: List of allowed values for decoding
+
+        Returns:
+            Python set or frozenset
+
+        Raises:
+            ValueError: If allowed_values is not provided
+        """
+        if allowed_values is None:
+            raise ValueError(
+                "Cannot decode SET from integer without allowed_values. "
+                "Provide allowed_values in constructor or options."
+            )
+
+        result = set()
+        for i, val in enumerate(allowed_values):
+            if value & (1 << i):
+                result.add(val)
+
+        return frozenset(result) if target_type is frozenset else result
+
+    def _decode_set_from_string(
+        self,
+        value: str,
+        target_type: Type
+    ) -> Union[set, frozenset]:
+        """
+        Decode MySQL SET from comma-separated string.
+
+        Args:
+            value: Comma-separated string
+            target_type: Target Python type (set or frozenset)
+
+        Returns:
+            Python set or frozenset
+        """
+        if not value:
+            result = set()
+        else:
+            result = set(value.split(','))
+        return frozenset(result) if target_type is frozenset else result
+
     def from_database(
         self,
         value: Any,
@@ -478,29 +532,12 @@ class MySQLSetAdapter(SQLTypeAdapter):
 
         # Handle integer storage (bit flags)
         if isinstance(value, int):
-            # MySQL stores SET as bit flags: bit 0 = first value, bit 1 = second, etc.
-            # Need allowed_values to decode
             allowed_values = self._allowed_values or (options.get('allowed_values') if options else None)
-            if allowed_values is None:
-                raise ValueError(
-                    "Cannot decode SET from integer without allowed_values. "
-                    "Provide allowed_values in constructor or options."
-                )
-
-            result = set()
-            for i, val in enumerate(allowed_values):
-                if value & (1 << i):
-                    result.add(val)
-
-            return frozenset(result) if target_type is frozenset else result
+            return self._decode_set_from_int(value, target_type, allowed_values)
 
         # Handle string storage (comma-separated)
         if isinstance(value, str):
-            if not value:
-                result = set()
-            else:
-                result = set(value.split(','))
-            return frozenset(result) if target_type is frozenset else result
+            return self._decode_set_from_string(value, target_type)
 
         raise TypeError(
             f"Cannot convert {type(value).__name__} to {target_type.__name__}"
@@ -595,6 +632,62 @@ class MySQLVectorAdapter(SQLTypeAdapter):
             return vector_str.encode('utf-8')
         return vector_str
 
+    def _decode_vector_from_bytes(self, value: bytes) -> List[float]:
+        """
+        Decode MySQL VECTOR from binary format.
+
+        Args:
+            value: Binary data (either UTF-8 encoded string or packed floats)
+
+        Returns:
+            List of float values
+
+        Raises:
+            ValueError: If binary format is invalid
+        """
+        # Try UTF-8 decode first (string format stored as bytes)
+        try:
+            return self._decode_vector_from_string(value.decode('utf-8'))
+        except UnicodeDecodeError:
+            pass
+
+        # Binary format: packed IEEE 754 float32 values (little-endian)
+        import struct
+        float_count = len(value) // 4
+        if len(value) % 4 != 0:
+            raise ValueError(
+                f"Invalid VECTOR binary length: {len(value)} bytes "
+                f"(must be multiple of 4 for float32 values)"
+            ) from None
+        return list(struct.unpack(f'<{float_count}f', value))
+
+    def _decode_vector_from_string(self, value: str) -> List[float]:
+        """
+        Decode MySQL VECTOR from string format.
+
+        Args:
+            value: String representation like '[1.0,2.0,3.0]'
+
+        Returns:
+            List of float values
+
+        Raises:
+            ValueError: If string cannot be parsed
+        """
+        # Remove brackets and split
+        value = value.strip()
+        if value.startswith('[') and value.endswith(']'):
+            value = value[1:-1]
+
+        if not value:
+            return []
+
+        # Split by comma and convert to floats
+        try:
+            return [float(v.strip()) for v in value.split(',')]
+        except ValueError as e:
+            raise ValueError(f"Cannot parse VECTOR value: {value}") from e
+
     def from_database(
         self,
         value: Any,
@@ -629,37 +722,13 @@ class MySQLVectorAdapter(SQLTypeAdapter):
         if isinstance(value, list):
             return [float(v) for v in value]
 
-        # Binary format - could be either string bytes or packed floats
+        # Binary format
         if isinstance(value, bytes):
-            # Try UTF-8 decode first (string format stored as bytes)
-            try:
-                value = value.decode('utf-8')
-            except UnicodeDecodeError:
-                # Binary format: packed IEEE 754 float32 values (little-endian)
-                import struct
-                float_count = len(value) // 4
-                if len(value) % 4 != 0:
-                    raise ValueError(
-                        f"Invalid VECTOR binary length: {len(value)} bytes "
-                        f"(must be multiple of 4 for float32 values)"
-                    ) from None
-                return list(struct.unpack(f'<{float_count}f', value))
+            return self._decode_vector_from_bytes(value)
 
-        # String format: '[1.0,2.0,3.0]' or similar
+        # String format
         if isinstance(value, str):
-            # Remove brackets and split
-            value = value.strip()
-            if value.startswith('[') and value.endswith(']'):
-                value = value[1:-1]
-
-            if not value:
-                return []
-
-            # Split by comma and convert to floats
-            try:
-                return [float(v.strip()) for v in value.split(',')]
-            except ValueError as e:
-                raise ValueError(f"Cannot parse VECTOR value: {value}") from e
+            return self._decode_vector_from_string(value)
 
         raise TypeError(
             f"Cannot convert {type(value).__name__} to vector (list of floats)"

--- a/src/rhosocial/activerecord/backend/impl/mysql/adapters.py
+++ b/src/rhosocial/activerecord/backend/impl/mysql/adapters.py
@@ -147,10 +147,13 @@ class MySQLDateAdapter(SQLTypeAdapter):
 class MySQLTimeAdapter(SQLTypeAdapter):
     """
     Adapts Python time to MySQL TIME string (HH:MM:SS) and vice-versa.
+
+    MySQL connector-python returns timedelta for TIME columns, but accepts
+    string format for insertion. This adapter handles both cases.
     """
     @property
     def supported_types(self) -> Dict[Type, List[Any]]:
-        return {datetime.time: [datetime.timedelta]}
+        return {datetime.time: [datetime.timedelta, str]}
 
     def to_database(self, value: datetime.time, target_type: Type, options: Optional[Dict[str, Any]] = None) -> Any:
         if value is None:
@@ -191,14 +194,11 @@ class MySQLDatetimeAdapter(SQLTypeAdapter):
     def to_database(self, value: datetime.datetime, target_type: Type, options: Optional[Dict[str, Any]] = None) -> Any:
         if value is None:
             return None
-        import sys
-        print(f"DEBUG MySQLDatetimeAdapter.to_database: version={self._mysql_version}, value={value}", file=sys.stderr)
         # If the datetime object is timezone-aware, normalize to UTC and make it naive
         # for the database driver, which expects naive datetimes.
         if value.tzinfo is not None:
             utc_dt = value.astimezone(datetime.timezone.utc).replace(tzinfo=None)
             # MySQL 5.7.8+ supports ISO 8601 format, older versions need traditional format
-            print(f"DEBUG: comparison result = {self._mysql_version >= (5, 7, 8)}", file=sys.stderr)
             if self._mysql_version >= (5, 7, 8):
                 return utc_dt.isoformat()
             else:
@@ -371,4 +371,296 @@ class MySQLEnumAdapter(SQLTypeAdapter):
 
         raise TypeError(
             f"Cannot convert {type(value).__name__} to {target_type.__name__}"
+        )
+
+
+class MySQLSetAdapter(SQLTypeAdapter):
+    """
+    Adapts Python set/frozenset to MySQL SET type and vice-versa.
+
+    MySQL SET is a string object that can have zero or more values,
+    each chosen from a predefined list. Values are stored as integers
+    (bit flags) internally but displayed/queried as comma-separated strings.
+
+    Features:
+    - Maximum 64 members (bit flags in BIGINT)
+    - Values are automatically sorted on storage
+    - Supports FIND_IN_SET and LIKE operations
+    """
+
+    def __init__(self, allowed_values: Optional[List[str]] = None):
+        """
+        Initialize MySQL SET adapter.
+
+        Args:
+            allowed_values: Optional list of allowed SET values for validation.
+                           If None, no validation is performed during conversion.
+        """
+        self._allowed_values = allowed_values
+
+    @property
+    def supported_types(self) -> Dict[Type, List[Any]]:
+        return {set: [str], frozenset: [str]}
+
+    def to_database(
+        self,
+        value: Union[set, frozenset],
+        target_type: Type,
+        options: Optional[Dict[str, Any]] = None
+    ) -> Any:
+        """
+        Convert Python set/frozenset to MySQL SET string.
+
+        Args:
+            value: Python set or frozenset
+            target_type: Target database type (str)
+            options: Optional settings:
+                - 'allowed_values': Override instance allowed values for validation
+
+        Returns:
+            Comma-separated string of sorted values
+
+        Raises:
+            ValueError: If values exceed 64 members or contain invalid values
+            TypeError: If target_type is not str
+        """
+        if value is None:
+            return None
+
+        if target_type is not str:
+            raise TypeError(
+                f"MySQL SET adapter only supports str target type, "
+                f"got {target_type.__name__}"
+            )
+
+        if len(value) > 64:
+            raise ValueError(
+                f"MySQL SET supports maximum 64 members, got {len(value)}"
+            )
+
+        # Get allowed values from options or instance
+        allowed_values = options.get('allowed_values', self._allowed_values) if options else self._allowed_values
+
+        if allowed_values is not None:
+            invalid_values = [v for v in value if v not in allowed_values]
+            if invalid_values:
+                raise ValueError(
+                    f"Invalid SET values: {invalid_values}. "
+                    f"Allowed values: {allowed_values}"
+                )
+
+        # MySQL automatically sorts SET values on storage
+        sorted_values = sorted(str(v) for v in value)
+        return ','.join(sorted_values) if sorted_values else ''
+
+    def from_database(
+        self,
+        value: Any,
+        target_type: Type,
+        options: Optional[Dict[str, Any]] = None
+    ) -> Optional[Union[set, frozenset]]:
+        """
+        Convert MySQL SET string to Python set/frozenset.
+
+        Args:
+            value: Database value (str or int)
+            target_type: Target Python type (set or frozenset)
+            options: Optional settings (currently unused)
+
+        Returns:
+            Python set or frozenset
+
+        Raises:
+            TypeError: If target_type is not set or frozenset
+        """
+        if value is None:
+            return None
+
+        # Handle integer storage (bit flags)
+        if isinstance(value, int):
+            # MySQL stores SET as bit flags: bit 0 = first value, bit 1 = second, etc.
+            # Need allowed_values to decode
+            allowed_values = self._allowed_values or (options.get('allowed_values') if options else None)
+            if allowed_values is None:
+                raise ValueError(
+                    "Cannot decode SET from integer without allowed_values. "
+                    "Provide allowed_values in constructor or options."
+                )
+
+            result = set()
+            for i, val in enumerate(allowed_values):
+                if value & (1 << i):
+                    result.add(val)
+
+            return frozenset(result) if target_type is frozenset else result
+
+        # Handle string storage (comma-separated)
+        if isinstance(value, str):
+            if not value:
+                result = set()
+            else:
+                result = set(value.split(','))
+            return frozenset(result) if target_type is frozenset else result
+
+        raise TypeError(
+            f"Cannot convert {type(value).__name__} to {target_type.__name__}"
+        )
+
+
+class MySQLVectorAdapter(SQLTypeAdapter):
+    """
+    Adapts Python list of floats to MySQL VECTOR type and vice-versa.
+
+    MySQL VECTOR type (9.0+) is used for AI/ML applications to store
+    multi-dimensional vectors. Supports up to 16,384 dimensions.
+
+    Storage format:
+    - Binary format internally (optimized for similarity operations)
+    - Can be read/written as string representation '[1.0,2.0,3.0]'
+
+    Supported distance functions:
+    - DISTANCE_EUCLIDEAN: Euclidean (L2) distance
+    - DISTANCE_COSINE: Cosine similarity distance
+    - DISTANCE_DOT: Dot product distance
+    """
+
+    # Maximum dimension supported by MySQL 9.0
+    MAX_VECTOR_DIMENSION = 16384
+
+    def __init__(self, dimension: Optional[int] = None):
+        """
+        Initialize VECTOR adapter.
+
+        Args:
+            dimension: Optional expected vector dimension for validation.
+                      If None, no dimension validation is performed.
+        """
+        self._dimension = dimension
+
+    @property
+    def supported_types(self) -> Dict[Type, List[Any]]:
+        # list[float] -> VECTOR (stored as binary or string)
+        return {list: [bytes, str]}
+
+    def to_database(
+        self,
+        value: List[float],
+        target_type: Type,
+        options: Optional[Dict[str, Any]] = None
+    ) -> Any:
+        """
+        Convert Python list of floats to MySQL VECTOR format.
+
+        Args:
+            value: List of float values
+            target_type: Target database type (bytes or str)
+            options: Optional settings:
+                - 'dimension': Override expected dimension for validation
+
+        Returns:
+            String representation '[v1,v2,...]' or binary format
+
+        Raises:
+            ValueError: If dimension exceeds maximum or doesn't match expected
+            TypeError: If value contains non-float elements
+        """
+        if value is None:
+            return None
+
+        dimension = options.get('dimension', self._dimension) if options else self._dimension
+
+        if len(value) > self.MAX_VECTOR_DIMENSION:
+            raise ValueError(
+                f"Vector dimension {len(value)} exceeds maximum "
+                f"supported dimension {self.MAX_VECTOR_DIMENSION}"
+            )
+
+        if dimension is not None and len(value) != dimension:
+            raise ValueError(
+                f"Vector dimension {len(value)} doesn't match expected dimension {dimension}"
+            )
+
+        # Validate all elements are floats or can be converted
+        for i, v in enumerate(value):
+            if not isinstance(v, (int, float)):
+                raise TypeError(
+                    f"Vector element at index {i} is not a number: {type(v).__name__}"
+                )
+
+        # MySQL accepts string format '[1.0,2.0,3.0]' for VECTOR
+        # or use STRING_TO_VECTOR function
+        vector_str = '[' + ','.join(str(float(v)) for v in value) + ']'
+
+        if target_type is bytes:
+            return vector_str.encode('utf-8')
+        return vector_str
+
+    def from_database(
+        self,
+        value: Any,
+        target_type: Type,
+        options: Optional[Dict[str, Any]] = None
+    ) -> Optional[List[float]]:
+        """
+        Convert MySQL VECTOR to Python list of floats.
+
+        Args:
+            value: Database value (bytes, str, or already parsed list)
+            target_type: Target Python type (list)
+            options: Optional settings (currently unused)
+
+        Returns:
+            List of float values
+
+        Raises:
+            TypeError: If target_type is not list
+            ValueError: If value cannot be parsed
+        """
+        if value is None:
+            return None
+
+        if target_type is not list:
+            raise TypeError(
+                f"MySQL VECTOR adapter only supports list target type, "
+                f"got {target_type.__name__}"
+            )
+
+        # Already a list (some drivers might parse it)
+        if isinstance(value, list):
+            return [float(v) for v in value]
+
+        # Binary format - could be either string bytes or packed floats
+        if isinstance(value, bytes):
+            # Try UTF-8 decode first (string format stored as bytes)
+            try:
+                value = value.decode('utf-8')
+            except UnicodeDecodeError:
+                # Binary format: packed IEEE 754 float32 values (little-endian)
+                import struct
+                float_count = len(value) // 4
+                if len(value) % 4 != 0:
+                    raise ValueError(
+                        f"Invalid VECTOR binary length: {len(value)} bytes "
+                        f"(must be multiple of 4 for float32 values)"
+                    ) from None
+                return list(struct.unpack(f'<{float_count}f', value))
+
+        # String format: '[1.0,2.0,3.0]' or similar
+        if isinstance(value, str):
+            # Remove brackets and split
+            value = value.strip()
+            if value.startswith('[') and value.endswith(']'):
+                value = value[1:-1]
+
+            if not value:
+                return []
+
+            # Split by comma and convert to floats
+            try:
+                return [float(v.strip()) for v in value.split(',')]
+            except ValueError as e:
+                raise ValueError(f"Cannot parse VECTOR value: {value}") from e
+
+        raise TypeError(
+            f"Cannot convert {type(value).__name__} to vector (list of floats)"
         )

--- a/src/rhosocial/activerecord/backend/impl/mysql/async_backend.py
+++ b/src/rhosocial/activerecord/backend/impl/mysql/async_backend.py
@@ -9,7 +9,7 @@ the synchronous backend but uses async/await for I/O operations.
 """
 import datetime
 import logging
-from typing import Dict, List, Optional, Tuple, Type, Union
+from typing import List, Optional, Tuple
 
 import mysql.connector.aio as mysql_async
 from mysql.connector.errors import (
@@ -17,7 +17,6 @@ from mysql.connector.errors import (
     Error as MySQLError,
     IntegrityError as MySQLIntegrityError,
     OperationalError as MySQLOperationalError,
-    ProgrammingError,
 )
 
 from rhosocial.activerecord.backend.base import AsyncStorageBackend
@@ -29,26 +28,14 @@ from rhosocial.activerecord.backend.errors import (
     OperationalError,
     QueryError,
 )
-from rhosocial.activerecord.backend.dialect.exceptions import UnsupportedFeatureError
-from rhosocial.activerecord.backend.type_adapter import SQLTypeAdapter
 from rhosocial.activerecord.backend.result import QueryResult
-from .adapters import (
-    MySQLBlobAdapter,
-    MySQLBooleanAdapter,
-    MySQLDateAdapter,
-    MySQLDatetimeAdapter,
-    MySQLDecimalAdapter,
-    MySQLEnumAdapter,
-    MySQLJSONAdapter,
-    MySQLTimeAdapter,
-    MySQLUUIDAdapter,
-)
 from .config import MySQLConnectionConfig
 from .dialect import MySQLDialect
 from .async_transaction import AsyncMySQLTransactionManager
+from .mixins import MySQLBackendMixin
 
 
-class AsyncMySQLBackend(AsyncStorageBackend):
+class AsyncMySQLBackend(MySQLBackendMixin, AsyncStorageBackend):
     """Asynchronous MySQL-specific backend implementation."""
 
     def __init__(self, **kwargs):
@@ -114,28 +101,6 @@ class AsyncMySQLBackend(AsyncStorageBackend):
 
         self.log(logging.INFO, "AsyncMySQLBackend initialized")
 
-    def _register_mysql_adapters(self):
-        """Register MySQL-specific type adapters."""
-        mysql_adapters = [
-            MySQLBlobAdapter(),
-            MySQLBooleanAdapter(),
-            MySQLDateAdapter(),
-            MySQLDatetimeAdapter(self._version),
-            MySQLDecimalAdapter(),
-            MySQLEnumAdapter(use_int_storage=False),  # Default to string representation
-            MySQLJSONAdapter(),
-            MySQLTimeAdapter(),
-            MySQLUUIDAdapter(),
-        ]
-
-        for adapter in mysql_adapters:
-            for py_type, db_types in adapter.supported_types.items():
-                for db_type in db_types:
-                    # Use allow_override=True to allow re-registration with updated version
-                    self.adapter_registry.register(adapter, py_type, db_type, allow_override=True)
-
-        self.log(logging.DEBUG, "Registered MySQL-specific type adapters")
-
     async def introspect_and_adapt(self) -> None:
         """Introspect backend and adapt backend instance to actual server capabilities.
 
@@ -151,21 +116,6 @@ class AsyncMySQLBackend(AsyncStorageBackend):
             self._dialect = MySQLDialect(actual_version)
             self._register_mysql_adapters()
             self.log(logging.INFO, f"Adapted to MySQL server version {actual_version}")
-
-    @property
-    def dialect(self):
-        """Get the MySQL dialect instance (lazy loads with configured version)."""
-        if self._dialect is None:
-            self._dialect = MySQLDialect(self._version)
-        return self._dialect
-
-    @property
-    def transaction_manager(self):
-        """Get the async MySQL transaction manager."""
-        # Update the transaction manager's connection if needed
-        if self._transaction_manager:
-            self._transaction_manager._connection = self._connection
-        return self._transaction_manager
 
     async def connect(self):
         """Establish async connection to MySQL database."""
@@ -204,7 +154,8 @@ class AsyncMySQLBackend(AsyncStorageBackend):
                 'read_timeout', 'write_timeout', 'use_pure', 'get_warnings',
                 'buffered', 'raw', 'compress', 'allow_local_infile', 'conn_attrs',
                 'client_flags', 'unix_socket', 'ssl_disabled'
-                # Note: Connection pool parameters (pool_name, pool_size, pool_pre_ping, etc.) are not supported by async connector
+                # Note: Connection pool parameters (pool_name, pool_size,
+                # pool_pre_ping, etc.) are not supported by async connector
             ]
 
             for param in additional_params:
@@ -226,10 +177,14 @@ class AsyncMySQLBackend(AsyncStorageBackend):
                 await cursor.execute(init_command)
                 await cursor.close()
 
-            self.log(logging.INFO, f"Connected to MySQL database: {self.config.host}:{self.config.port}/{self.config.database}")
+            self.log(
+                logging.INFO,
+                f"Connected to MySQL database: "
+                f"{self.config.host}:{self.config.port}/{self.config.database}"
+            )
         except mysql_async.Error as e:
             self.log(logging.ERROR, f"Failed to connect to MySQL database: {str(e)}")
-            raise ConnectionError(f"Failed to connect to MySQL: {str(e)}")
+            raise ConnectionError(f"Failed to connect to MySQL: {str(e)}") from e
 
     async def disconnect(self):
         """Close async connection to MySQL database."""
@@ -244,7 +199,7 @@ class AsyncMySQLBackend(AsyncStorageBackend):
                 self.log(logging.INFO, "Disconnected from MySQL database")
             except mysql_async.Error as e:
                 self.log(logging.ERROR, f"Error during disconnection: {str(e)}")
-                raise OperationalError(f"Error during MySQL disconnection: {str(e)}")
+                raise OperationalError(f"Error during MySQL disconnection: {str(e)}") from e
 
     async def _get_cursor(self):
         """Get a database cursor, ensuring connection is active."""
@@ -286,18 +241,22 @@ class AsyncMySQLBackend(AsyncStorageBackend):
                 duration=duration
             )
 
-            self.log(logging.INFO, f"Batch operation completed, affected {affected_rows} rows, duration={duration:.3f}s")
+            self.log(
+                logging.INFO,
+                f"Batch operation completed, affected {affected_rows} rows, "
+                f"duration={duration:.3f}s"
+            )
             return result
 
         except MySQLIntegrityError as e:
             self.log(logging.ERROR, f"Integrity error in batch: {str(e)}")
-            raise IntegrityError(str(e))
+            raise IntegrityError(str(e)) from e
         except MySQLError as e:
             self.log(logging.ERROR, f"MySQL error in batch: {str(e)}")
-            raise DatabaseError(str(e))
+            raise DatabaseError(str(e)) from e
         except Exception as e:
             self.log(logging.ERROR, f"Unexpected error during batch execution: {str(e)}")
-            raise QueryError(str(e))
+            raise QueryError(str(e)) from e
         finally:
             if cursor:
                 await cursor.close()
@@ -332,23 +291,6 @@ class AsyncMySQLBackend(AsyncStorageBackend):
         finally:
             if cursor:
                 await cursor.close()
-
-    def requires_manual_commit(self) -> bool:
-        """Check if manual commit is required for this database."""
-        return not getattr(self.config, 'autocommit', True)
-
-    def _check_returning_compatibility(self, returning_clause):
-        """Check if RETURNING clause is compatible with this MySQL version."""
-        # MySQL does not support RETURNING clause
-        if self.dialect.supports_returning_clause():
-            return True
-        else:
-            raise UnsupportedFeatureError(
-                self.name,
-                "RETURNING clause",
-                "MySQL does not support RETURNING clause. "
-                "Consider using LAST_INSERT_ID() or alternative approaches."
-            )
 
     async def ping(self, reconnect: bool = True) -> bool:
         """Ping the MySQL server to check if the connection is alive."""
@@ -447,68 +389,6 @@ class AsyncMySQLBackend(AsyncStorageBackend):
                 await self._connection.commit()
                 self.log(logging.DEBUG, "Auto-committed operation (not in active transaction)")
 
-    def get_default_adapter_suggestions(self) -> Dict[Type, Tuple['SQLTypeAdapter', Type]]:
-        """
-        [Backend Implementation] Provides default type adapter suggestions for MySQL.
-
-        This method defines a curated set of type adapter suggestions for common Python
-        types, mapping them to their typical MySQL-compatible representations as
-        demonstrated in test fixtures. It explicitly retrieves necessary `SQLTypeAdapter`
-        instances from the backend's `adapter_registry`. If an adapter for a specific
-        (Python type, DB driver type) pair is not registered, no suggestion will be
-        made for that Python type.
-
-        Returns:
-            Dict[Type, Tuple[SQLTypeAdapter, Type]]: A dictionary where keys are
-            original Python types (`TypeRegistry`'s `py_type`), and values are
-            tuples containing a `SQLTypeAdapter` instance and the target
-            Python type (`TypeRegistry`'s `db_type`) expected by the driver.
-        """
-        suggestions: Dict[Type, Tuple['SQLTypeAdapter', Type]] = {}
-
-        # Define a list of desired Python type to DB driver type mappings.
-        # This list reflects types seen in test fixtures and common usage,
-        # along with their preferred database-compatible Python types for the driver.
-        # Types that are natively compatible with the DB driver (e.g., Python str, int, float)
-        # and for which no specific conversion logic is needed are omitted from this list.
-        # The consuming layer should assume pass-through behavior for any Python type
-        # that does not have an explicit adapter suggestion.
-        #
-        # Exception: If a user requires specific processing for a natively compatible type
-        # (e.g., custom serialization/deserialization for JSON strings beyond basic conversion),
-        # they would need to implement and register their own specialized adapter.
-        # This backend's default suggestions do not cater to such advanced processing needs.
-        from datetime import date, datetime, time
-        from decimal import Decimal
-        from uuid import UUID
-        from enum import Enum
-
-        type_mappings = [
-            (bool, int),        # Python bool -> DB driver int (MySQL TINYINT)
-            # Why str for date/time?
-            # MySQL accepts string representations of dates/times and converts them appropriately.
-            (datetime, str),    # Python datetime -> DB driver str (MySQL DATETIME/TIMESTAMP)
-            (date, str),        # Python date -> DB driver str (MySQL DATE)
-            (time, str),        # Python time -> DB driver str (MySQL TIME)
-            (Decimal, float),   # Python Decimal -> DB driver float (MySQL DECIMAL)
-            (UUID, str),        # Python UUID -> DB driver str (MySQL CHAR/VARCHAR/BINARY)
-            (dict, str),        # Python dict -> DB driver str (MySQL TEXT for JSON)
-            (list, str),        # Python list -> DB driver str (MySQL TEXT for JSON)
-            (Enum, str),        # Python Enum -> DB driver str (MySQL TEXT/VARCHAR)
-        ]
-
-        # Iterate through the defined mappings and retrieve adapters from the registry.
-        for py_type, db_type in type_mappings:
-            adapter = self.adapter_registry.get_adapter(py_type, db_type)
-            if adapter:
-                suggestions[py_type] = (adapter, db_type)
-            else:
-                # Log a debug message if a specific adapter is expected but not found.
-                self.log(logging.DEBUG, f"No adapter found for ({py_type.__name__}, {db_type.__name__}). "
-                                      "Suggestion will not be provided for this type.")
-
-        return suggestions
-
     async def execute(self, sql: str, params: Optional[Tuple] = None, *, options=None, **kwargs) -> QueryResult:
         """Execute a SQL statement with optional parameters asynchronously."""
         from rhosocial.activerecord.backend.options import ExecutionOptions, StatementType
@@ -548,11 +428,3 @@ class AsyncMySQLBackend(AsyncStorageBackend):
             return await super().execute(mysql_sql, params, options=options)
         else:
             return await super().execute(sql, params, options=options)
-
-    def log(self, level: int, message: str):
-        """Log a message with the specified level."""
-        if hasattr(self, '_logger') and self._logger:
-            self._logger.log(level, message)
-        else:
-            # Fallback logging
-            print(f"[{logging.getLevelName(level)}] {message}")

--- a/src/rhosocial/activerecord/backend/impl/mysql/async_transaction.py
+++ b/src/rhosocial/activerecord/backend/impl/mysql/async_transaction.py
@@ -6,23 +6,27 @@ This module provides async transaction management capabilities for MySQL,
 including savepoints and proper isolation level handling.
 """
 import logging
-from typing import Dict, Optional
 
 from rhosocial.activerecord.backend.transaction import (
     AsyncTransactionManager,
     IsolationLevel,
     TransactionState,
-    TransactionError
+    TransactionError,
 )
+from .mixins import MySQLTransactionMixin
 
 
-class AsyncMySQLTransactionManager(AsyncTransactionManager):
+class AsyncMySQLTransactionManager(MySQLTransactionMixin, AsyncTransactionManager):
     """Asynchronous transaction manager for MySQL backend."""
+
+    _ISOLATION_LEVELS = MySQLTransactionMixin._ISOLATION_LEVELS
 
     def __init__(self, connection, logger=None):
         """Initialize async MySQL transaction manager."""
         super().__init__(connection, logger)
         self._savepoint_counter = 0
+        self._isolation_level = IsolationLevel.REPEATABLE_READ
+        self._state = TransactionState.INACTIVE
 
     async def _ensure_connection_ready(self):
         """Ensure connection is ready for transaction operations asynchronously."""
@@ -39,7 +43,7 @@ class AsyncMySQLTransactionManager(AsyncTransactionManager):
         except Exception:
             error_msg = "Connection is not active"
             self.log(logging.ERROR, error_msg)
-            raise TransactionError(error_msg)
+            raise TransactionError(error_msg) from None
 
     async def _do_begin(self) -> None:
         """Begin a new transaction"""

--- a/src/rhosocial/activerecord/backend/impl/mysql/backend.py
+++ b/src/rhosocial/activerecord/backend/impl/mysql/backend.py
@@ -8,10 +8,7 @@ specific behaviors and SQL dialect.
 """
 import datetime
 import logging
-import re
-import uuid
-from decimal import Decimal
-from typing import Dict, List, Optional, Tuple, Type, Union
+from typing import List, Optional, Tuple
 
 import mysql.connector
 from mysql.connector.errors import (
@@ -19,7 +16,6 @@ from mysql.connector.errors import (
     Error as MySQLError,
     IntegrityError as MySQLIntegrityError,
     OperationalError as MySQLOperationalError,
-    ProgrammingError,
 )
 
 from rhosocial.activerecord.backend.base import StorageBackend
@@ -31,28 +27,14 @@ from rhosocial.activerecord.backend.errors import (
     OperationalError,
     QueryError,
 )
-from rhosocial.activerecord.backend.dialect.exceptions import UnsupportedFeatureError
-from rhosocial.activerecord.backend.type_adapter import SQLTypeAdapter
 from rhosocial.activerecord.backend.result import QueryResult
-from rhosocial.activerecord.backend.config import ConnectionConfig
-from .adapters import (
-    MySQLBlobAdapter,
-    MySQLBooleanAdapter,
-    MySQLDateAdapter,
-    MySQLDatetimeAdapter,
-    MySQLDecimalAdapter,
-    MySQLEnumAdapter,
-    MySQLJSONAdapter,
-    MySQLSetAdapter,
-    MySQLTimeAdapter,
-    MySQLUUIDAdapter,
-)
 from .config import MySQLConnectionConfig
 from .dialect import MySQLDialect
 from .transaction import MySQLTransactionManager
+from .mixins import MySQLBackendMixin
 
 
-class MySQLBackend(StorageBackend):
+class MySQLBackend(MySQLBackendMixin, StorageBackend):
     """MySQL-specific backend implementation."""
 
     def __init__(self, **kwargs):
@@ -120,29 +102,6 @@ class MySQLBackend(StorageBackend):
 
         self.log(logging.INFO, "MySQLBackend initialized")
 
-    def _register_mysql_adapters(self):
-        """Register MySQL-specific type adapters."""
-        mysql_adapters = [
-            MySQLBlobAdapter(),
-            MySQLBooleanAdapter(),
-            MySQLDateAdapter(),
-            MySQLDatetimeAdapter(self._version),
-            MySQLDecimalAdapter(),
-            MySQLEnumAdapter(use_int_storage=False),  # Default to string representation
-            MySQLJSONAdapter(),
-            MySQLSetAdapter(),  # MySQL SET type support
-            MySQLTimeAdapter(),
-            MySQLUUIDAdapter(),
-        ]
-
-        for adapter in mysql_adapters:
-            for py_type, db_types in adapter.supported_types.items():
-                for db_type in db_types:
-                    # Use allow_override=True to replace default adapters with MySQL-specific ones
-                    self.adapter_registry.register(adapter, py_type, db_type, allow_override=True)
-
-        self.log(logging.DEBUG, "Registered MySQL-specific type adapters")
-
     def introspect_and_adapt(self) -> None:
         """Introspect backend and adapt backend instance to actual server capabilities.
 
@@ -158,21 +117,6 @@ class MySQLBackend(StorageBackend):
             self._dialect = MySQLDialect(actual_version)
             self._register_mysql_adapters()
             self.log(logging.INFO, f"Adapted to MySQL server version {actual_version}")
-
-    @property
-    def dialect(self):
-        """Get the MySQL dialect instance (lazy loads with configured version)."""
-        if self._dialect is None:
-            self._dialect = MySQLDialect(self._version)
-        return self._dialect
-
-    @property
-    def transaction_manager(self):
-        """Get the MySQL transaction manager."""
-        # Update the transaction manager's connection if needed
-        if self._transaction_manager:
-            self._transaction_manager._connection = self._connection
-        return self._transaction_manager
 
     def connect(self):
         """Establish connection to MySQL database."""
@@ -233,10 +177,14 @@ class MySQLBackend(StorageBackend):
                 cursor.execute(init_command)
                 cursor.close()
 
-            self.log(logging.INFO, f"Connected to MySQL database: {self.config.host}:{self.config.port}/{self.config.database}")
+            self.log(
+                logging.INFO,
+                f"Connected to MySQL database: "
+                f"{self.config.host}:{self.config.port}/{self.config.database}"
+            )
         except MySQLError as e:
             self.log(logging.ERROR, f"Failed to connect to MySQL database: {str(e)}")
-            raise ConnectionError(f"Failed to connect to MySQL: {str(e)}")
+            raise ConnectionError(f"Failed to connect to MySQL: {str(e)}") from e
 
     def disconnect(self):
         """Close connection to MySQL database."""
@@ -251,7 +199,7 @@ class MySQLBackend(StorageBackend):
                 self.log(logging.INFO, "Disconnected from MySQL database")
             except MySQLError as e:
                 self.log(logging.ERROR, f"Error during disconnection: {str(e)}")
-                raise OperationalError(f"Error during MySQL disconnection: {str(e)}")
+                raise OperationalError(f"Error during MySQL disconnection: {str(e)}") from e
 
     def _get_cursor(self):
         """Get a database cursor, ensuring connection is active."""
@@ -291,18 +239,22 @@ class MySQLBackend(StorageBackend):
                 duration=duration
             )
             
-            self.log(logging.INFO, f"Batch operation completed, affected {affected_rows} rows, duration={duration:.3f}s")
+            self.log(
+                logging.INFO,
+                f"Batch operation completed, affected {affected_rows} rows, "
+                f"duration={duration:.3f}s"
+            )
             return result
             
         except MySQLIntegrityError as e:
             self.log(logging.ERROR, f"Integrity error in batch: {str(e)}")
-            raise IntegrityError(str(e))
+            raise IntegrityError(str(e)) from e
         except MySQLError as e:
             self.log(logging.ERROR, f"MySQL error in batch: {str(e)}")
-            raise DatabaseError(str(e))
+            raise DatabaseError(str(e)) from e
         except Exception as e:
             self.log(logging.ERROR, f"Unexpected error during batch execution: {str(e)}")
-            raise QueryError(str(e))
+            raise QueryError(str(e)) from e
         finally:
             if cursor:
                 cursor.close()
@@ -336,23 +288,6 @@ class MySQLBackend(StorageBackend):
         finally:
             if cursor:
                 cursor.close()
-
-    def requires_manual_commit(self) -> bool:
-        """Check if manual commit is required for this database."""
-        return not getattr(self.config, 'autocommit', True)
-
-    def _check_returning_compatibility(self, returning_clause):
-        """Check if RETURNING clause is compatible with this MySQL version."""
-        # MySQL does not support RETURNING clause
-        if self.dialect.supports_returning_clause():
-            return True
-        else:
-            raise UnsupportedFeatureError(
-                self.name,
-                "RETURNING clause",
-                "MySQL does not support RETURNING clause. "
-                "Consider using LAST_INSERT_ID() or alternative approaches."
-            )
 
     def ping(self, reconnect: bool = True) -> bool:
         """Ping the MySQL server to check if the connection is alive."""
@@ -451,70 +386,6 @@ class MySQLBackend(StorageBackend):
                 self._connection.commit()
                 self.log(logging.DEBUG, "Auto-committed operation (not in active transaction)")
 
-    def get_default_adapter_suggestions(self) -> Dict[Type, Tuple['SQLTypeAdapter', Type]]:
-        """
-        [Backend Implementation] Provides default type adapter suggestions for MySQL.
-
-        This method defines a curated set of type adapter suggestions for common Python
-        types, mapping them to their typical MySQL-compatible representations as
-        demonstrated in test fixtures. It explicitly retrieves necessary `SQLTypeAdapter`
-        instances from the backend's `adapter_registry`. If an adapter for a specific
-        (Python type, DB driver type) pair is not registered, no suggestion will be
-        made for that Python type.
-
-        Returns:
-            Dict[Type, Tuple[SQLTypeAdapter, Type]]: A dictionary where keys are
-            original Python types (`TypeRegistry`'s `py_type`), and values are
-            tuples containing a `SQLTypeAdapter` instance and the target
-            Python type (`TypeRegistry`'s `db_type`) expected by the driver.
-        """
-        suggestions: Dict[Type, Tuple['SQLTypeAdapter', Type]] = {}
-
-        # Define a list of desired Python type to DB driver type mappings.
-        # This list reflects types seen in test fixtures and common usage,
-        # along with their preferred database-compatible Python types for the driver.
-        # Types that are natively compatible with the DB driver (e.g., Python str, int, float)
-        # and for which no specific conversion logic is needed are omitted from this list.
-        # The consuming layer should assume pass-through behavior for any Python type
-        # that does not have an explicit adapter suggestion.
-        #
-        # Exception: If a user requires specific processing for a natively compatible type
-        # (e.g., custom serialization/deserialization for JSON strings beyond basic conversion),
-        # they would need to implement and register their own specialized adapter.
-        # This backend's default suggestions do not cater to such advanced processing needs.
-        from datetime import date, datetime, time
-        from decimal import Decimal
-        from uuid import UUID
-        from enum import Enum
-
-        type_mappings = [
-            (bool, int),        # Python bool -> DB driver int (MySQL TINYINT)
-            # Why str for date/time?
-            # MySQL accepts string representations of dates/times and converts them appropriately.
-            (datetime, str),    # Python datetime -> DB driver str (MySQL DATETIME/TIMESTAMP)
-            (date, str),        # Python date -> DB driver str (MySQL DATE)
-            (time, str),        # Python time -> DB driver str (MySQL TIME)
-            (Decimal, float),   # Python Decimal -> DB driver float (MySQL DECIMAL)
-            (UUID, str),        # Python UUID -> DB driver str (MySQL CHAR/VARCHAR/BINARY)
-            (dict, str),        # Python dict -> DB driver str (MySQL TEXT for JSON)
-            (list, str),        # Python list -> DB driver str (MySQL TEXT for JSON)
-            (Enum, str),        # Python Enum -> DB driver str (MySQL TEXT/VARCHAR)
-            (set, str),         # Python set -> DB driver str (MySQL SET)
-            (frozenset, str),   # Python frozenset -> DB driver str (MySQL SET)
-        ]
-
-        # Iterate through the defined mappings and retrieve adapters from the registry.
-        for py_type, db_type in type_mappings:
-            adapter = self.adapter_registry.get_adapter(py_type, db_type)
-            if adapter:
-                suggestions[py_type] = (adapter, db_type)
-            else:
-                # Log a debug message if a specific adapter is expected but not found.
-                self.log(logging.DEBUG, f"No adapter found for ({py_type.__name__}, {db_type.__name__}). "
-                                      "Suggestion will not be provided for this type.")
-
-        return suggestions
-
     def execute(self, sql: str, params: Optional[Tuple] = None, *, options=None, **kwargs) -> QueryResult:
         """Execute a SQL statement with optional parameters."""
         from rhosocial.activerecord.backend.options import ExecutionOptions, StatementType
@@ -554,11 +425,3 @@ class MySQLBackend(StorageBackend):
             return super().execute(mysql_sql, params, options=options)
         else:
             return super().execute(sql, params, options=options)
-
-    def log(self, level: int, message: str):
-        """Log a message with the specified level."""
-        if hasattr(self, '_logger') and self._logger:
-            self._logger.log(level, message)
-        else:
-            # Fallback logging
-            print(f"[{logging.getLevelName(level)}] {message}")

--- a/src/rhosocial/activerecord/backend/impl/mysql/backend.py
+++ b/src/rhosocial/activerecord/backend/impl/mysql/backend.py
@@ -43,6 +43,7 @@ from .adapters import (
     MySQLDecimalAdapter,
     MySQLEnumAdapter,
     MySQLJSONAdapter,
+    MySQLSetAdapter,
     MySQLTimeAdapter,
     MySQLUUIDAdapter,
 )
@@ -129,6 +130,7 @@ class MySQLBackend(StorageBackend):
             MySQLDecimalAdapter(),
             MySQLEnumAdapter(use_int_storage=False),  # Default to string representation
             MySQLJSONAdapter(),
+            MySQLSetAdapter(),  # MySQL SET type support
             MySQLTimeAdapter(),
             MySQLUUIDAdapter(),
         ]
@@ -497,6 +499,8 @@ class MySQLBackend(StorageBackend):
             (dict, str),        # Python dict -> DB driver str (MySQL TEXT for JSON)
             (list, str),        # Python list -> DB driver str (MySQL TEXT for JSON)
             (Enum, str),        # Python Enum -> DB driver str (MySQL TEXT/VARCHAR)
+            (set, str),         # Python set -> DB driver str (MySQL SET)
+            (frozenset, str),   # Python frozenset -> DB driver str (MySQL SET)
         ]
 
         # Iterate through the defined mappings and retrieve adapters from the registry.

--- a/src/rhosocial/activerecord/backend/impl/mysql/dialect.py
+++ b/src/rhosocial/activerecord/backend/impl/mysql/dialect.py
@@ -64,6 +64,7 @@ from .protocols import (
     MySQLSetTypeSupport,
     MySQLJSONFunctionSupport,
     MySQLSpatialSupport,
+    MySQLVectorSupport,
 )
 from .mixins import (
     MySQLTriggerMixin,
@@ -71,6 +72,7 @@ from .mixins import (
     MySQLSetTypeMixin,
     MySQLJSONFunctionMixin,
     MySQLSpatialMixin,
+    MySQLVectorMixin,
 )
 
 if TYPE_CHECKING:
@@ -111,6 +113,7 @@ class MySQLDialect(
     MySQLSetTypeMixin,
     MySQLJSONFunctionMixin,
     MySQLSpatialMixin,
+    MySQLVectorMixin,  # MySQL 9.0+ VECTOR type support
     # Protocols for type checking
     CTESupport,
     FilterClauseSupport,
@@ -141,6 +144,7 @@ class MySQLDialect(
     MySQLSetTypeSupport,
     MySQLJSONFunctionSupport,
     MySQLSpatialSupport,
+    MySQLVectorSupport,  # MySQL 9.0+ VECTOR type support
 ):
     """
     MySQL dialect implementation that adapts to the MySQL version.
@@ -864,4 +868,48 @@ class MySQLDialect(
         """MySQL supports QUERY EXPANSION."""
         return True  # All versions with FULLTEXT support this
 
+    # endregion
+
+    # region MySQL 8.0 Index Features
+    def supports_invisible_index(self) -> bool:
+        """Whether INVISIBLE indexes are supported.
+
+        MySQL 8.0+ supports invisible indexes that are not used by the optimizer.
+        """
+        return self.version >= (8, 0, 0)
+
+    def supports_descending_index(self) -> bool:
+        """Whether descending indexes are supported.
+
+        MySQL 8.0+ supports true descending indexes (not just reverse scans).
+        """
+        return self.version >= (8, 0, 0)
+
+    def supports_functional_index(self) -> bool:
+        """Whether functional (expression) indexes are supported.
+
+        MySQL 8.0+ supports indexes on expressions (functional indexes).
+        """
+        return self.version >= (8, 0, 0)
+
+    def supports_check_constraint(self) -> bool:
+        """Whether CHECK constraints are enforced.
+
+        MySQL 8.0.16+ enforces CHECK constraints (before that, they were parsed but ignored).
+        """
+        return self.version >= (8, 0, 16)
+
+    def supports_generated_column(self) -> bool:
+        """Whether generated (computed) columns are supported.
+
+        MySQL 5.7+ supports generated columns (STORED and VIRTUAL).
+        """
+        return self.version >= (5, 7, 0)
+
+    def supports_default_column_value_expression(self) -> bool:
+        """Whether DEFAULT column values can use expressions.
+
+        MySQL 8.0+ supports expressions in DEFAULT column values.
+        """
+        return self.version >= (8, 0, 0)
     # endregion

--- a/src/rhosocial/activerecord/backend/impl/mysql/mixins.py
+++ b/src/rhosocial/activerecord/backend/impl/mysql/mixins.py
@@ -679,3 +679,174 @@ class MySQLSpatialMixin:
             f"({self.format_identifier(column)})",
             ()
         )
+
+
+class MySQLVectorMixin:
+    """MySQL vector data type implementation.
+
+    MySQL VECTOR type (since 9.0+) features:
+    - Multi-dimensional vector storage for AI/ML applications
+    - Similarity search with distance functions
+    - Maximum 16,384 dimensions
+    - Binary storage format for optimized operations
+    - VECTOR indexes for fast similarity search
+
+    Version Requirements:
+    - VECTOR type: MySQL 9.0+
+    - VECTOR indexes: MySQL 9.0.1+
+    """
+
+    # Maximum dimension supported by MySQL 9.0
+    MAX_VECTOR_DIMENSION = 16384
+
+    def supports_vector_type(self) -> bool:
+        """VECTOR type is supported since MySQL 9.0."""
+        return self.version >= (9, 0, 0)
+
+    def supports_vector_index(self) -> bool:
+        """VECTOR indexes are supported since MySQL 9.0.1."""
+        return self.version >= (9, 0, 1)
+
+    def get_max_vector_dimension(self) -> int:
+        """Get maximum supported vector dimension."""
+        return self.MAX_VECTOR_DIMENSION
+
+    def format_vector_literal(
+        self,
+        values: List[float]
+    ) -> Tuple[str, tuple]:
+        """Format VECTOR literal value.
+
+        Args:
+            values: List of float values representing the vector
+
+        Returns:
+            Tuple of (SQL string, parameters tuple)
+        """
+        if len(values) > self.MAX_VECTOR_DIMENSION:
+            raise ValueError(
+                f"Vector dimension {len(values)} exceeds maximum "
+                f"supported dimension {self.MAX_VECTOR_DIMENSION}"
+            )
+        # Use STRING_TO_VECTOR for literal creation
+        vector_str = '[' + ','.join(str(v) for v in values) + ']'
+        return "STRING_TO_VECTOR(%s)", (vector_str,)
+
+    def format_string_to_vector(
+        self,
+        vector_str: str
+    ) -> Tuple[str, tuple]:
+        """Format STRING_TO_VECTOR function.
+
+        Args:
+            vector_str: String representation of vector (e.g., '[1.0,2.0,3.0]')
+
+        Returns:
+            Tuple of (SQL string, parameters tuple)
+        """
+        return "STRING_TO_VECTOR(%s)", (vector_str,)
+
+    def format_vector_to_string(
+        self,
+        vector_col: str
+    ) -> Tuple[str, tuple]:
+        """Format VECTOR_TO_STRING function.
+
+        Args:
+            vector_col: VECTOR column name
+
+        Returns:
+            Tuple of (SQL string, parameters tuple)
+        """
+        return f"VECTOR_TO_STRING({vector_col})", ()
+
+    def format_vector_dim(
+        self,
+        vector_col: str
+    ) -> Tuple[str, tuple]:
+        """Format VECTOR_DIM function.
+
+        Args:
+            vector_col: VECTOR column name
+
+        Returns:
+            Tuple of (SQL string, parameters tuple)
+        """
+        return f"VECTOR_DIM({vector_col})", ()
+
+    def format_distance_euclidean(
+        self,
+        vector1: str,
+        vector2: str
+    ) -> Tuple[str, tuple]:
+        """Format DISTANCE_EUCLIDEAN function.
+
+        Args:
+            vector1: First vector (column or literal)
+            vector2: Second vector (column or literal)
+
+        Returns:
+            Tuple of (SQL string, parameters tuple)
+        """
+        return f"DISTANCE_EUCLIDEAN({vector1}, {vector2})", ()
+
+    def format_distance_cosine(
+        self,
+        vector1: str,
+        vector2: str
+    ) -> Tuple[str, tuple]:
+        """Format DISTANCE_COSINE function.
+
+        Args:
+            vector1: First vector (column or literal)
+            vector2: Second vector (column or literal)
+
+        Returns:
+            Tuple of (SQL string, parameters tuple)
+        """
+        return f"DISTANCE_COSINE({vector1}, {vector2})", ()
+
+    def format_distance_dot(
+        self,
+        vector1: str,
+        vector2: str
+    ) -> Tuple[str, tuple]:
+        """Format DISTANCE_DOT function.
+
+        Args:
+            vector1: First vector (column or literal)
+            vector2: Second vector (column or literal)
+
+        Returns:
+            Tuple of (SQL string, parameters tuple)
+        """
+        return f"DISTANCE_DOT({vector1}, {vector2})", ()
+
+    def format_create_vector_index(
+        self,
+        index_name: str,
+        table_name: str,
+        column: str
+    ) -> Tuple[str, tuple]:
+        """Format CREATE VECTOR INDEX statement.
+
+        Note: MySQL uses CREATE INDEX with VECTOR keyword, not CREATE VECTOR INDEX.
+
+        Args:
+            index_name: Name of the vector index
+            table_name: Name of the table
+            column: VECTOR column name
+
+        Returns:
+            Tuple of (SQL string, parameters tuple)
+        """
+        if not self.supports_vector_index():
+            from rhosocial.activerecord.backend.dialect.exceptions import UnsupportedFeatureError
+            raise UnsupportedFeatureError(self.name, "VECTOR indexes (requires MySQL 9.0.1+)")
+        # MySQL 9.0.1+ syntax for vector index
+        return (
+            f"CREATE VECTOR INDEX {self.format_identifier(index_name)} "
+            f"ON {self.format_identifier(table_name)} "
+            f"({self.format_identifier(column)})",
+            ()
+        )

--- a/src/rhosocial/activerecord/backend/impl/mysql/mixins.py
+++ b/src/rhosocial/activerecord/backend/impl/mysql/mixins.py
@@ -1,5 +1,210 @@
 """MySQL dialect-specific Mixin implementations."""
-from typing import Any, Dict, List, Optional, Tuple, Union
+import logging
+from typing import Any, Dict, List, Optional, Tuple, Type
+
+from rhosocial.activerecord.backend.type_adapter import SQLTypeAdapter
+from rhosocial.activerecord.backend.errors import TransactionError
+from rhosocial.activerecord.backend.transaction import IsolationLevel
+
+
+class MySQLTransactionMixin:
+    """MySQL transaction common functionality.
+
+    Provides shared isolation level management for both sync and async
+    MySQL transaction managers.
+    """
+
+    _ISOLATION_LEVELS: Dict[IsolationLevel, str] = {
+        IsolationLevel.READ_UNCOMMITTED: "READ UNCOMMITTED",
+        IsolationLevel.READ_COMMITTED: "READ COMMITTED",
+        IsolationLevel.REPEATABLE_READ: "REPEATABLE READ",
+        IsolationLevel.SERIALIZABLE: "SERIALIZABLE"
+    }
+
+    @property
+    def isolation_level(self) -> Optional[IsolationLevel]:
+        """Get current transaction isolation level."""
+        return self._isolation_level
+
+    @isolation_level.setter
+    def isolation_level(self, level: Optional[IsolationLevel]):
+        """Set transaction isolation level."""
+        from rhosocial.activerecord.backend.transaction import IsolationLevelError
+        self.log(logging.DEBUG, f"Setting isolation level to {level}")
+        if self.is_active:
+            self.log(logging.ERROR, "Cannot change isolation level during active transaction")
+            raise IsolationLevelError("Cannot change isolation level during active transaction")
+
+        if level is not None and level not in self._ISOLATION_LEVELS:
+            error_msg = f"Unsupported isolation level: {level}"
+            self.log(logging.ERROR, error_msg)
+            raise TransactionError(error_msg)
+
+        self._isolation_level = level
+
+
+class MySQLBackendMixin:
+    """MySQL backend common functionality.
+
+    Provides shared non-I/O methods for both sync and async MySQL backends.
+    This mixin assumes the following attributes exist in the class:
+    - self._version: MySQL server version tuple
+    - self._dialect: MySQLDialect instance (lazy loaded)
+    - self._transaction_manager: Transaction manager instance
+    - self._connection: Database connection
+    - self.adapter_registry: Type adapter registry
+    - self.config: Connection configuration
+    - self._logger: Logger instance
+    """
+
+    def _register_mysql_adapters(self):
+        """Register MySQL-specific type adapters."""
+        from .adapters import (
+            MySQLBlobAdapter,
+            MySQLBooleanAdapter,
+            MySQLDateAdapter,
+            MySQLDatetimeAdapter,
+            MySQLDecimalAdapter,
+            MySQLEnumAdapter,
+            MySQLJSONAdapter,
+            MySQLSetAdapter,
+            MySQLTimeAdapter,
+            MySQLUUIDAdapter,
+        )
+
+        mysql_adapters = [
+            MySQLBlobAdapter(),
+            MySQLBooleanAdapter(),
+            MySQLDateAdapter(),
+            MySQLDatetimeAdapter(self._version),
+            MySQLDecimalAdapter(),
+            MySQLEnumAdapter(use_int_storage=False),  # Default to string representation
+            MySQLJSONAdapter(),
+            MySQLSetAdapter(),  # MySQL SET type support
+            MySQLTimeAdapter(),
+            MySQLUUIDAdapter(),
+        ]
+
+        for adapter in mysql_adapters:
+            for py_type, db_types in adapter.supported_types.items():
+                for db_type in db_types:
+                    # Use allow_override=True to replace default adapters with MySQL-specific ones
+                    self.adapter_registry.register(adapter, py_type, db_type, allow_override=True)
+
+        self.log(logging.DEBUG, "Registered MySQL-specific type adapters")
+
+    @property
+    def dialect(self):
+        """Get the MySQL dialect instance (lazy loads with configured version)."""
+        from .dialect import MySQLDialect
+        if self._dialect is None:
+            self._dialect = MySQLDialect(self._version)
+        return self._dialect
+
+    @property
+    def transaction_manager(self):
+        """Get the MySQL transaction manager."""
+        # Update the transaction manager's connection if needed
+        if self._transaction_manager:
+            self._transaction_manager._connection = self._connection
+        return self._transaction_manager
+
+    def requires_manual_commit(self) -> bool:
+        """Check if manual commit is required for this database."""
+        return not getattr(self.config, 'autocommit', True)
+
+    def _check_returning_compatibility(self, _returning_clause):
+        """Check if RETURNING clause is compatible with this MySQL version.
+
+        Args:
+            _returning_clause: Unused parameter (MySQL doesn't support RETURNING).
+        """
+        from rhosocial.activerecord.backend.dialect.exceptions import UnsupportedFeatureError
+        # MySQL does not support RETURNING clause
+        if self.dialect.supports_returning_clause():
+            return True
+        else:
+            raise UnsupportedFeatureError(
+                self.name,
+                "RETURNING clause",
+                "MySQL does not support RETURNING clause. "
+                "Consider using LAST_INSERT_ID() or alternative approaches."
+            )
+
+    def get_default_adapter_suggestions(self) -> Dict[Type, Tuple[SQLTypeAdapter, Type]]:
+        """
+        [Backend Implementation] Provides default type adapter suggestions for MySQL.
+
+        This method defines a curated set of type adapter suggestions for common Python
+        types, mapping them to their typical MySQL-compatible representations as
+        demonstrated in test fixtures. It explicitly retrieves necessary `SQLTypeAdapter`
+        instances from the backend's `adapter_registry`. If an adapter for a specific
+        (Python type, DB driver type) pair is not registered, no suggestion will be
+        made for that Python type.
+
+        Returns:
+            Dict[Type, Tuple[SQLTypeAdapter, Type]]: A dictionary where keys are
+            original Python types (`TypeRegistry`'s `py_type`), and values are
+            tuples containing a `SQLTypeAdapter` instance and the target
+            Python type (`TypeRegistry`'s `db_type`) expected by the driver.
+        """
+        from datetime import date, datetime, time
+        from decimal import Decimal
+        from uuid import UUID
+        from enum import Enum
+
+        suggestions: Dict[Type, Tuple[SQLTypeAdapter, Type]] = {}
+
+        # Define a list of desired Python type to DB driver type mappings.
+        # This list reflects types seen in test fixtures and common usage,
+        # along with their preferred database-compatible Python types for the driver.
+        # Types that are natively compatible with the DB driver (e.g., Python str, int, float)
+        # and for which no specific conversion logic is needed are omitted from this list.
+        # The consuming layer should assume pass-through behavior for any Python type
+        # that does not have an explicit adapter suggestion.
+        #
+        # Exception: If a user requires specific processing for a natively compatible type
+        # (e.g., custom serialization/deserialization for JSON strings beyond basic conversion),
+        # they would need to implement and register their own specialized adapter.
+        # This backend's default suggestions do not cater to such advanced processing needs.
+        type_mappings = [
+            (bool, int),        # Python bool -> DB driver int (MySQL TINYINT)
+            # Why str for date/time?
+            # MySQL accepts string representations of dates/times and converts them appropriately.
+            (datetime, str),    # Python datetime -> DB driver str (MySQL DATETIME/TIMESTAMP)
+            (date, str),        # Python date -> DB driver str (MySQL DATE)
+            (time, str),        # Python time -> DB driver str (MySQL TIME)
+            (Decimal, float),   # Python Decimal -> DB driver float (MySQL DECIMAL)
+            (UUID, str),        # Python UUID -> DB driver str (MySQL CHAR/VARCHAR/BINARY)
+            (dict, str),        # Python dict -> DB driver str (MySQL TEXT for JSON)
+            (list, str),        # Python list -> DB driver str (MySQL TEXT for JSON)
+            (Enum, str),        # Python Enum -> DB driver str (MySQL TEXT/VARCHAR)
+            (set, str),         # Python set -> DB driver str (MySQL SET)
+            (frozenset, str),   # Python frozenset -> DB driver str (MySQL SET)
+        ]
+
+        # Iterate through the defined mappings and retrieve adapters from the registry.
+        for py_type, db_type in type_mappings:
+            adapter = self.adapter_registry.get_adapter(py_type, db_type)
+            if adapter:
+                suggestions[py_type] = (adapter, db_type)
+            else:
+                # Log a debug message if a specific adapter is expected but not found.
+                self.log(
+                    logging.DEBUG,
+                    f"No adapter found for ({py_type.__name__}, {db_type.__name__}). "
+                    "Suggestion will not be provided for this type."
+                )
+
+        return suggestions
+
+    def log(self, level: int, message: str):
+        """Log a message with the specified level."""
+        if hasattr(self, '_logger') and self._logger:
+            self._logger.log(level, message)
+        else:
+            # Fallback logging
+            print(f"[{logging.getLevelName(level)}] {message}")
 
 
 class MySQLTriggerMixin:

--- a/src/rhosocial/activerecord/backend/impl/mysql/protocols.py
+++ b/src/rhosocial/activerecord/backend/impl/mysql/protocols.py
@@ -597,3 +597,176 @@ class MySQLSpatialSupport(Protocol):
             Tuple of (SQL string, parameters tuple)
         """
         ...
+
+
+@runtime_checkable
+class MySQLVectorSupport(Protocol):
+    """MySQL vector data type protocol.
+
+    Feature Source: MySQL 9.0+ (AI/ML vector storage)
+
+    MySQL VECTOR type features:
+    - VECTOR: Store multi-dimensional vectors for AI/ML applications
+    - Supports similarity search with vector distance functions
+    - Maximum dimension: 16,384
+    - Storage: Binary format (optimized for similarity operations)
+    - Indexing: Supports VECTOR index for fast similarity search
+
+    Vector Functions (MySQL 9.0+):
+    - VECTOR_DIM(): Get vector dimension
+    - STRING_TO_VECTOR(): Convert string to vector
+    - VECTOR_TO_STRING(): Convert vector to string
+    - DISTANCE_EUCLIDEAN(): Euclidean distance
+    - DISTANCE_COSINE(): Cosine distance
+    - DISTANCE_DOT(): Dot product distance
+
+    Official Documentation:
+    - VECTOR Type: https://dev.mysql.com/doc/refman/9.0/en/vector-type.html
+    - Vector Functions: https://dev.mysql.com/doc/refman/9.0/en/spatial-vector-functions.html
+
+    Version Requirements:
+    - VECTOR type and functions: MySQL 9.0+
+    """
+
+    def supports_vector_type(self) -> bool:
+        """Whether VECTOR type is supported.
+
+        MySQL 9.0+ supports VECTOR type for AI/ML applications.
+        """
+        ...
+
+    def supports_vector_index(self) -> bool:
+        """Whether VECTOR indexes are supported.
+
+        MySQL 9.0.1+ supports VECTOR indexes for fast similarity search.
+        """
+        ...
+
+    def get_max_vector_dimension(self) -> int:
+        """Get maximum supported vector dimension.
+
+        MySQL 9.0 supports up to 16,384 dimensions.
+        """
+        ...
+
+    def format_vector_literal(
+        self,
+        values: List[float]
+    ) -> Tuple[str, tuple]:
+        """Format VECTOR literal value.
+
+        Args:
+            values: List of float values representing the vector
+
+        Returns:
+            Tuple of (SQL string, parameters tuple)
+        """
+        ...
+
+    def format_string_to_vector(
+        self,
+        vector_str: str
+    ) -> Tuple[str, tuple]:
+        """Format STRING_TO_VECTOR function.
+
+        Args:
+            vector_str: String representation of vector
+
+        Returns:
+            Tuple of (SQL string, parameters tuple)
+        """
+        ...
+
+    def format_vector_to_string(
+        self,
+        vector_col: str
+    ) -> Tuple[str, tuple]:
+        """Format VECTOR_TO_STRING function.
+
+        Args:
+            vector_col: VECTOR column name
+
+        Returns:
+            Tuple of (SQL string, parameters tuple)
+        """
+        ...
+
+    def format_vector_dim(
+        self,
+        vector_col: str
+    ) -> Tuple[str, tuple]:
+        """Format VECTOR_DIM function.
+
+        Args:
+            vector_col: VECTOR column name
+
+        Returns:
+            Tuple of (SQL string, parameters tuple)
+        """
+        ...
+
+    def format_distance_euclidean(
+        self,
+        vector1: str,
+        vector2: str
+    ) -> Tuple[str, tuple]:
+        """Format DISTANCE_EUCLIDEAN function.
+
+        Args:
+            vector1: First vector (column or literal)
+            vector2: Second vector (column or literal)
+
+        Returns:
+            Tuple of (SQL string, parameters tuple)
+        """
+        ...
+
+    def format_distance_cosine(
+        self,
+        vector1: str,
+        vector2: str
+    ) -> Tuple[str, tuple]:
+        """Format DISTANCE_COSINE function.
+
+        Args:
+            vector1: First vector (column or literal)
+            vector2: Second vector (column or literal)
+
+        Returns:
+            Tuple of (SQL string, parameters tuple)
+        """
+        ...
+
+    def format_distance_dot(
+        self,
+        vector1: str,
+        vector2: str
+    ) -> Tuple[str, tuple]:
+        """Format DISTANCE_DOT function.
+
+        Args:
+            vector1: First vector (column or literal)
+            vector2: Second vector (column or literal)
+
+        Returns:
+            Tuple of (SQL string, parameters tuple)
+        """
+        ...
+
+    def format_create_vector_index(
+        self,
+        index_name: str,
+        table_name: str,
+        column: str
+    ) -> Tuple[str, tuple]:
+        """Format CREATE VECTOR INDEX statement.
+
+        Args:
+            index_name: Name of the vector index
+            table_name: Name of the table
+            column: VECTOR column name
+
+        Returns:
+            Tuple of (SQL string, parameters tuple)
+        """
+        ...

--- a/src/rhosocial/activerecord/backend/impl/mysql/transaction.py
+++ b/src/rhosocial/activerecord/backend/impl/mysql/transaction.py
@@ -1,73 +1,27 @@
 # src/rhosocial/activerecord/backend/impl/mysql/transaction.py
+"""MySQL synchronous transaction manager implementation."""
 import logging
-from typing import Dict, Optional
 from mysql.connector.errors import Error as MySQLError, ProgrammingError
 
 from rhosocial.activerecord.backend.errors import TransactionError
 from rhosocial.activerecord.backend.transaction import (
-    TransactionManager,
-    AsyncTransactionManager,
     IsolationLevel,
+    TransactionManager,
     TransactionState,
-    IsolationLevelError
 )
+from .mixins import MySQLTransactionMixin
 
 
-class MySQLTransactionManager(TransactionManager):
+class MySQLTransactionManager(MySQLTransactionMixin, TransactionManager):
     """MySQL synchronous transaction manager implementation."""
 
-    _ISOLATION_LEVELS: Dict[IsolationLevel, str] = {
-        IsolationLevel.READ_UNCOMMITTED: "READ UNCOMMITTED",
-        IsolationLevel.READ_COMMITTED: "READ COMMITTED",
-        IsolationLevel.REPEATABLE_READ: "REPEATABLE READ",
-        IsolationLevel.SERIALIZABLE: "SERIALIZABLE"
-    }
+    _ISOLATION_LEVELS = MySQLTransactionMixin._ISOLATION_LEVELS
 
     def __init__(self, connection, logger=None):
         """Initialize MySQL transaction manager."""
         super().__init__(connection, logger)
         self._isolation_level = IsolationLevel.REPEATABLE_READ
         self._state = TransactionState.INACTIVE
-
-    @property
-    def isolation_level(self) -> Optional[IsolationLevel]:
-        """Get current transaction isolation level."""
-        return self._isolation_level
-
-    @isolation_level.setter
-    def isolation_level(self, level: Optional[IsolationLevel]):
-        """Set transaction isolation level."""
-        self.log(logging.DEBUG, f"Setting isolation level to {level}")
-        if self.is_active:
-            self.log(logging.ERROR, "Cannot change isolation level during active transaction")
-            raise IsolationLevelError("Cannot change isolation level during active transaction")
-
-        if level is not None and level not in self._ISOLATION_LEVELS:
-            error_msg = f"Unsupported isolation level: {level}"
-            self.log(logging.ERROR, error_msg)
-            raise TransactionError(error_msg)
-
-        self._isolation_level = level
-
-    @property
-    def isolation_level(self) -> Optional[IsolationLevel]:
-        """Get current transaction isolation level."""
-        return self._isolation_level
-
-    @isolation_level.setter
-    def isolation_level(self, level: Optional[IsolationLevel]):
-        """Set transaction isolation level."""
-        self.log(logging.DEBUG, f"Setting isolation level to {level}")
-        if self.is_active:
-            self.log(logging.ERROR, "Cannot change isolation level during active transaction")
-            raise IsolationLevelError("Cannot change isolation level during active transaction")
-
-        if level is not None and level not in self._ISOLATION_LEVELS:
-            error_msg = f"Unsupported isolation level: {level}"
-            self.log(logging.ERROR, error_msg)
-            raise TransactionError(error_msg)
-
-        self._isolation_level = level
 
     def _ensure_connection_ready(self):
         """Ensure connection is ready for transaction operations."""
@@ -85,7 +39,7 @@ class MySQLTransactionManager(TransactionManager):
         except MySQLError:
             error_msg = "Connection is not active"
             self.log(logging.ERROR, error_msg)
-            raise TransactionError(error_msg)
+            raise TransactionError(error_msg) from None
 
     def _do_begin(self) -> None:
         """Begin MySQL transaction."""
@@ -117,11 +71,11 @@ class MySQLTransactionManager(TransactionManager):
             else:
                 error_msg = f"Failed to begin transaction: {str(e)}"
                 self.log(logging.ERROR, error_msg)
-                raise TransactionError(error_msg)
+                raise TransactionError(error_msg) from e
         except MySQLError as e:
             error_msg = f"Failed to begin transaction: {str(e)}"
             self.log(logging.ERROR, error_msg)
-            raise TransactionError(error_msg)
+            raise TransactionError(error_msg) from e
 
     def _do_commit(self) -> None:
         """Commit MySQL transaction."""
@@ -134,7 +88,7 @@ class MySQLTransactionManager(TransactionManager):
         except MySQLError as e:
             error_msg = f"Failed to commit transaction: {str(e)}"
             self.log(logging.ERROR, error_msg)
-            raise TransactionError(error_msg)
+            raise TransactionError(error_msg) from e
 
     def _do_rollback(self) -> None:
         """Rollback MySQL transaction."""
@@ -147,7 +101,7 @@ class MySQLTransactionManager(TransactionManager):
         except MySQLError as e:
             error_msg = f"Failed to rollback transaction: {str(e)}"
             self.log(logging.ERROR, error_msg)
-            raise TransactionError(error_msg)
+            raise TransactionError(error_msg) from e
 
     def _do_create_savepoint(self, name: str) -> None:
         """Create MySQL savepoint."""
@@ -161,7 +115,7 @@ class MySQLTransactionManager(TransactionManager):
         except MySQLError as e:
             error_msg = f"Failed to create savepoint {name}: {str(e)}"
             self.log(logging.ERROR, error_msg)
-            raise TransactionError(error_msg)
+            raise TransactionError(error_msg) from e
 
     def _do_release_savepoint(self, name: str) -> None:
         """Release MySQL savepoint."""
@@ -175,7 +129,7 @@ class MySQLTransactionManager(TransactionManager):
         except MySQLError as e:
             error_msg = f"Failed to release savepoint {name}: {str(e)}"
             self.log(logging.ERROR, error_msg)
-            raise TransactionError(error_msg)
+            raise TransactionError(error_msg) from e
 
     def _do_rollback_savepoint(self, name: str) -> None:
         """Rollback to MySQL savepoint."""
@@ -189,156 +143,8 @@ class MySQLTransactionManager(TransactionManager):
         except MySQLError as e:
             error_msg = f"Failed to rollback to savepoint {name}: {str(e)}"
             self.log(logging.ERROR, error_msg)
-            raise TransactionError(error_msg)
+            raise TransactionError(error_msg) from e
 
     def supports_savepoint(self) -> bool:
         """Check if savepoints are supported."""
-        return True
-
-
-class AsyncMySQLTransactionManager(AsyncTransactionManager):
-    """MySQL asynchronous transaction manager implementation."""
-
-    _ISOLATION_LEVELS: Dict[IsolationLevel, str] = {
-        IsolationLevel.READ_UNCOMMITTED: "READ UNCOMMITTED",
-        IsolationLevel.READ_COMMITTED: "READ COMMITTED",
-        IsolationLevel.REPEATABLE_READ: "REPEATABLE READ",
-        IsolationLevel.SERIALIZABLE: "SERIALIZABLE"
-    }
-
-    def __init__(self, connection, logger=None):
-        """Initialize async MySQL transaction manager."""
-        super().__init__(connection, logger)
-        self._isolation_level = IsolationLevel.REPEATABLE_READ
-        self._state = TransactionState.INACTIVE
-
-    @property
-    def isolation_level(self) -> Optional[IsolationLevel]:
-        """Get current transaction isolation level."""
-        return self._isolation_level
-
-    @isolation_level.setter
-    def isolation_level(self, level: Optional[IsolationLevel]):
-        """Set transaction isolation level."""
-        self.log(logging.DEBUG, f"Setting isolation level to {level}")
-        if self.is_active:
-            self.log(logging.ERROR, "Cannot change isolation level during active transaction")
-            raise IsolationLevelError("Cannot change isolation level during active transaction")
-
-        if level is not None and level not in self._ISOLATION_LEVELS:
-            error_msg = f"Unsupported isolation level: {level}"
-            self.log(logging.ERROR, error_msg)
-            raise TransactionError(error_msg)
-
-        self._isolation_level = level
-
-    async def _ensure_connection_ready(self):
-        """Ensure connection is ready for transaction operations asynchronously."""
-        if not self._connection:
-            error_msg = "No valid connection for transaction"
-            self.log(logging.ERROR, error_msg)
-            raise TransactionError(error_msg)
-
-    async def _ensure_connection_ready(self):
-        """Ensure connection is ready for transaction operations asynchronously."""
-        if not self._connection:
-            error_msg = "No valid connection for transaction"
-            self.log(logging.ERROR, error_msg)
-            raise TransactionError(error_msg)
-
-        # For async connections, we might need to check differently
-        # This depends on the async MySQL driver being used (aiomysql, asyncmy, etc.)
-
-    async def _do_begin(self) -> None:
-        """Begin MySQL transaction asynchronously."""
-        await self._ensure_connection_ready()
-
-        try:
-            isolation_string = self._ISOLATION_LEVELS.get(self._isolation_level)
-
-            # Set isolation level
-            cursor = await self._connection.cursor()
-            await cursor.execute(f"SET TRANSACTION ISOLATION LEVEL {isolation_string}")
-
-            # Start transaction
-            await cursor.execute("START TRANSACTION")
-            await cursor.close()
-
-            self._state = TransactionState.ACTIVE
-            self.log(logging.DEBUG, f"Started MySQL transaction with isolation level {isolation_string}")
-        except Exception as e:
-            error_msg = f"Failed to begin transaction: {str(e)}"
-            self.log(logging.ERROR, error_msg)
-            raise TransactionError(error_msg)
-
-    async def _do_commit(self) -> None:
-        """Commit MySQL transaction asynchronously."""
-        await self._ensure_connection_ready()
-
-        try:
-            await self._connection.commit()
-            self._state = TransactionState.COMMITTED
-            self.log(logging.DEBUG, "Committed MySQL transaction")
-        except Exception as e:
-            error_msg = f"Failed to commit transaction: {str(e)}"
-            self.log(logging.ERROR, error_msg)
-            raise TransactionError(error_msg)
-
-    async def _do_rollback(self) -> None:
-        """Rollback MySQL transaction asynchronously."""
-        await self._ensure_connection_ready()
-
-        try:
-            await self._connection.rollback()
-            self._state = TransactionState.ROLLED_BACK
-            self.log(logging.DEBUG, "Rolled back MySQL transaction")
-        except Exception as e:
-            error_msg = f"Failed to rollback transaction: {str(e)}"
-            self.log(logging.ERROR, error_msg)
-            raise TransactionError(error_msg)
-
-    async def _do_create_savepoint(self, name: str) -> None:
-        """Create MySQL savepoint asynchronously."""
-        await self._ensure_connection_ready()
-
-        try:
-            cursor = await self._connection.cursor()
-            await cursor.execute(f"SAVEPOINT {name}")
-            await cursor.close()
-            self.log(logging.DEBUG, f"Created savepoint: {name}")
-        except Exception as e:
-            error_msg = f"Failed to create savepoint {name}: {str(e)}"
-            self.log(logging.ERROR, error_msg)
-            raise TransactionError(error_msg)
-
-    async def _do_release_savepoint(self, name: str) -> None:
-        """Release MySQL savepoint asynchronously."""
-        await self._ensure_connection_ready()
-
-        try:
-            cursor = await self._connection.cursor()
-            await cursor.execute(f"RELEASE SAVEPOINT {name}")
-            await cursor.close()
-            self.log(logging.DEBUG, f"Released savepoint: {name}")
-        except Exception as e:
-            error_msg = f"Failed to release savepoint {name}: {str(e)}"
-            self.log(logging.ERROR, error_msg)
-            raise TransactionError(error_msg)
-
-    async def _do_rollback_savepoint(self, name: str) -> None:
-        """Rollback to MySQL savepoint asynchronously."""
-        await self._ensure_connection_ready()
-
-        try:
-            cursor = await self._connection.cursor()
-            await cursor.execute(f"ROLLBACK TO SAVEPOINT {name}")
-            await cursor.close()
-            self.log(logging.DEBUG, f"Rolled back to savepoint: {name}")
-        except Exception as e:
-            error_msg = f"Failed to rollback to savepoint {name}: {str(e)}"
-            self.log(logging.ERROR, error_msg)
-            raise TransactionError(error_msg)
-
-    async def supports_savepoint(self) -> bool:
-        """Check if savepoints are supported asynchronously."""
         return True

--- a/tests/rhosocial/activerecord_mysql_test/feature/backend/test_set_vector_adapters.py
+++ b/tests/rhosocial/activerecord_mysql_test/feature/backend/test_set_vector_adapters.py
@@ -1,0 +1,192 @@
+# tests/rhosocial/activerecord_mysql_test/feature/backend/test_set_vector_adapters.py
+"""
+Unit tests for MySQL SET and VECTOR type adapters.
+
+This module tests the internal helper methods of MySQLSetAdapter and MySQLVectorAdapter
+to ensure proper code coverage for refactored methods.
+"""
+import pytest
+import struct
+
+from rhosocial.activerecord.backend.impl.mysql.adapters import (
+    MySQLSetAdapter,
+    MySQLVectorAdapter,
+)
+
+
+class TestMySQLSetAdapterDecodeFromInt:
+    """Tests for MySQLSetAdapter._decode_set_from_int method."""
+
+    def test_decode_single_bit(self):
+        """Test decoding single bit set."""
+        adapter = MySQLSetAdapter(allowed_values=['a', 'b', 'c'])
+        # Bit 0 = 'a' (value 1)
+        result = adapter._decode_set_from_int(1, set, ['a', 'b', 'c'])
+        assert result == {'a'}
+
+    def test_decode_multiple_bits(self):
+        """Test decoding multiple bits set."""
+        adapter = MySQLSetAdapter(allowed_values=['red', 'green', 'blue'])
+        # Bit 0 = 'red' (1), Bit 1 = 'green' (2), Bit 2 = 'blue' (4)
+        # Value 3 = red + green
+        result = adapter._decode_set_from_int(3, set, ['red', 'green', 'blue'])
+        assert result == {'red', 'green'}
+
+    def test_decode_all_bits(self):
+        """Test decoding all bits set."""
+        adapter = MySQLSetAdapter(allowed_values=['a', 'b', 'c'])
+        # Value 7 = all bits set (1 + 2 + 4)
+        result = adapter._decode_set_from_int(7, set, ['a', 'b', 'c'])
+        assert result == {'a', 'b', 'c'}
+
+    def test_decode_returns_frozenset(self):
+        """Test that target_type=frozenset returns frozenset."""
+        adapter = MySQLSetAdapter(allowed_values=['x', 'y'])
+        result = adapter._decode_set_from_int(3, frozenset, ['x', 'y'])
+        assert isinstance(result, frozenset)
+        assert result == frozenset({'x', 'y'})
+
+    def test_decode_zero_value(self):
+        """Test decoding zero (empty set)."""
+        adapter = MySQLSetAdapter(allowed_values=['a', 'b', 'c'])
+        result = adapter._decode_set_from_int(0, set, ['a', 'b', 'c'])
+        assert result == set()
+
+    def test_decode_without_allowed_values_raises_error(self):
+        """Test that decoding without allowed_values raises ValueError."""
+        adapter = MySQLSetAdapter()
+        with pytest.raises(ValueError, match="Cannot decode SET from integer without allowed_values"):
+            adapter._decode_set_from_int(1, set, None)
+
+
+class TestMySQLSetAdapterDecodeFromString:
+    """Tests for MySQLSetAdapter._decode_set_from_string method."""
+
+    def test_decode_single_value(self):
+        """Test decoding single value string."""
+        adapter = MySQLSetAdapter()
+        result = adapter._decode_set_from_string('red', set)
+        assert result == {'red'}
+
+    def test_decode_multiple_values(self):
+        """Test decoding comma-separated values."""
+        adapter = MySQLSetAdapter()
+        result = adapter._decode_set_from_string('red,green,blue', set)
+        assert result == {'red', 'green', 'blue'}
+
+    def test_decode_empty_string(self):
+        """Test decoding empty string returns empty set."""
+        adapter = MySQLSetAdapter()
+        result = adapter._decode_set_from_string('', set)
+        assert result == set()
+
+    def test_decode_returns_frozenset(self):
+        """Test that target_type=frozenset returns frozenset."""
+        adapter = MySQLSetAdapter()
+        result = adapter._decode_set_from_string('a,b', frozenset)
+        assert isinstance(result, frozenset)
+        assert result == frozenset({'a', 'b'})
+
+
+class TestMySQLVectorAdapterDecodeFromBytes:
+    """Tests for MySQLVectorAdapter._decode_vector_from_bytes method."""
+
+    def test_decode_utf8_string_bytes(self):
+        """Test decoding UTF-8 encoded string format."""
+        adapter = MySQLVectorAdapter()
+        # UTF-8 encoded string format
+        result = adapter._decode_vector_from_bytes(b'[1.0,2.0,3.0]')
+        assert result == [1.0, 2.0, 3.0]
+
+    def test_decode_binary_format(self):
+        """Test decoding packed binary format (IEEE 754 float32)."""
+        adapter = MySQLVectorAdapter()
+        # Pack 3 float32 values in little-endian
+        binary_data = struct.pack('<3f', 1.0, 2.0, 3.0)
+        result = adapter._decode_vector_from_bytes(binary_data)
+        assert len(result) == 3
+        assert abs(result[0] - 1.0) < 1e-6
+        assert abs(result[1] - 2.0) < 1e-6
+        assert abs(result[2] - 3.0) < 1e-6
+
+    def test_decode_binary_invalid_length_raises_error(self):
+        """Test that invalid binary length raises ValueError."""
+        adapter = MySQLVectorAdapter()
+        # 5 bytes is not a multiple of 4, and contains invalid UTF-8 sequences
+        # Use bytes that cannot be decoded as UTF-8
+        invalid_data = b'\xff\xfe\xfd\xfc\xfb'  # Invalid UTF-8, 5 bytes
+        with pytest.raises(ValueError, match="Invalid VECTOR binary length"):
+            adapter._decode_vector_from_bytes(invalid_data)
+
+
+class TestMySQLVectorAdapterDecodeFromString:
+    """Tests for MySQLVectorAdapter._decode_vector_from_string method."""
+
+    def test_decode_bracketed_format(self):
+        """Test decoding standard bracketed format."""
+        adapter = MySQLVectorAdapter()
+        result = adapter._decode_vector_from_string('[1.5,2.5,3.5]')
+        assert result == [1.5, 2.5, 3.5]
+
+    def test_decode_single_value(self):
+        """Test decoding single value."""
+        adapter = MySQLVectorAdapter()
+        result = adapter._decode_vector_from_string('[42.0]')
+        assert result == [42.0]
+
+    def test_decode_empty_brackets(self):
+        """Test decoding empty brackets returns empty list."""
+        adapter = MySQLVectorAdapter()
+        result = adapter._decode_vector_from_string('[]')
+        assert result == []
+
+    def test_decode_with_spaces(self):
+        """Test decoding with whitespace."""
+        adapter = MySQLVectorAdapter()
+        result = adapter._decode_vector_from_string('[ 1.0 , 2.0 , 3.0 ]')
+        assert result == [1.0, 2.0, 3.0]
+
+    def test_decode_without_brackets(self):
+        """Test decoding format without brackets."""
+        adapter = MySQLVectorAdapter()
+        result = adapter._decode_vector_from_string('1.0,2.0,3.0')
+        assert result == [1.0, 2.0, 3.0]
+
+    def test_decode_invalid_value_raises_error(self):
+        """Test that invalid value raises ValueError."""
+        adapter = MySQLVectorAdapter()
+        with pytest.raises(ValueError, match="Cannot parse VECTOR value"):
+            adapter._decode_vector_from_string('[1.0,invalid,3.0]')
+
+
+class TestMySQLSetAdapterFromDatabaseIntegration:
+    """Integration tests for MySQLSetAdapter.from_database using helper methods."""
+
+    def test_from_database_int_calls_decode_from_int(self):
+        """Test that from_database with int calls _decode_set_from_int."""
+        adapter = MySQLSetAdapter(allowed_values=['a', 'b', 'c'])
+        # Value 5 = bit 0 + bit 2 = 'a' + 'c'
+        result = adapter.from_database(5, set)
+        assert result == {'a', 'c'}
+
+    def test_from_database_string_calls_decode_from_string(self):
+        """Test that from_database with str calls _decode_set_from_string."""
+        adapter = MySQLSetAdapter()
+        result = adapter.from_database('a,b,c', set)
+        assert result == {'a', 'b', 'c'}
+
+
+class TestMySQLVectorAdapterFromDatabaseIntegration:
+    """Integration tests for MySQLVectorAdapter.from_database using helper methods."""
+
+    def test_from_database_bytes_calls_decode_from_bytes(self):
+        """Test that from_database with bytes calls _decode_vector_from_bytes."""
+        adapter = MySQLVectorAdapter()
+        result = adapter.from_database(b'[1.0,2.0]', list)
+        assert result == [1.0, 2.0]
+
+    def test_from_database_string_calls_decode_from_string(self):
+        """Test that from_database with str calls _decode_vector_from_string."""
+        adapter = MySQLVectorAdapter()
+        result = adapter.from_database('[1.5,2.5,3.5]', list)
+        assert result == [1.5, 2.5, 3.5]


### PR DESCRIPTION
## Summary

This PR adds MySQL SET and VECTOR type support, and refactors backend code to extract common functionality into mixin classes.

## Changes

### New Features

- **MySQL SET type support**: Add `MySQLSetAdapter` for Python `set`/`frozenset` to MySQL SET conversion
- **MySQL VECTOR type support**: Add `MySQLVectorAdapter` for AI/ML vector storage (MySQL 9.0+)
- **Vector operations**: Add `MySQLVectorMixin` and `MySQLVectorSupport` protocol for vector operations
- **MySQL 8.0 index feature detection**:
  - `supports_invisible_index()`
  - `supports_descending_index()`
  - `supports_functional_index()`
  - `supports_check_constraint()`
  - `supports_generated_column()`
  - `supports_default_column_value_expression()`

### Bug Fixes

- Remove DEBUG print statements from `MySQLDatetimeAdapter`
- Update `MySQLTimeAdapter` to support `str` type for TIME columns

### Refactoring

- Add `MySQLTransactionMixin` with isolation level management
- Add `MySQLBackendMixin` with non-I/O methods
- Update `MySQLBackend`/`AsyncMySQLBackend` to inherit from `MySQLBackendMixin`
- Update `MySQLTransactionManager`/`AsyncMySQLTransactionManager` to inherit from `MySQLTransactionMixin`
- Remove duplicate code from sync/async implementations

## Test Plan

- [x] All tests pass with Python 3.8 and 3.12
- [x] View execution tests pass across MySQL 5.6, 5.7, 8.0, 8.4, 9.2, 9.6

## Commits

1. `2aa188e` feat(backend): add MySQL SET and VECTOR type support
2. `55b1678` refactor(backend): extract common code to mixin classes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
