### PR TITLE
feat(backend): add transaction expression support for MySQL dialect

### DIFF
--- a/changelog.d/24.added.md
+++ b/changelog.d/24.added.md
@@ -1,0 +1,1 @@
+Added transaction control support for MySQL dialect with TransactionControlSupport protocol implementation, including isolation level and access mode (READ ONLY/READ WRITE) control via SET TRANSACTION and START TRANSACTION statements.

--- a/src/rhosocial/activerecord/backend/impl/mysql/async_backend.py
+++ b/src/rhosocial/activerecord/backend/impl/mysql/async_backend.py
@@ -94,9 +94,8 @@ class AsyncMySQLBackend(AsyncExplainBackendMixin, IntrospectorBackendMixin, MySQ
         self._version = version
         # Initialize MySQL-specific components (lazy load dialect)
         self._dialect = None
-        # Initialize transaction manager with connection (will be set when connected)
-        # Pass None for connection initially, it will be updated later
-        self._transaction_manager = AsyncMySQLTransactionManager(None, self.logger)
+        # Initialize transaction manager (will use backend.execute())
+        self._transaction_manager = AsyncMySQLTransactionManager(self, self.logger)
 
         # Register MySQL-specific type adapters (uses self._version)
         self._register_mysql_adapters()

--- a/src/rhosocial/activerecord/backend/impl/mysql/async_transaction.py
+++ b/src/rhosocial/activerecord/backend/impl/mysql/async_transaction.py
@@ -3,14 +3,17 @@
 Asynchronous transaction management for MySQL backend.
 
 This module provides async transaction management capabilities for MySQL.
-All transaction operations are delegated to the base class
-which uses backend.execute() for SQL execution.
+MySQL requires SET TRANSACTION ISOLATION LEVEL to be executed before
+START TRANSACTION as separate statements. This class overrides _do_begin()
+to handle this sequencing properly.
 """
-from typing import TYPE_CHECKING
+import logging
+from typing import TYPE_CHECKING, Optional, Tuple
 
 from rhosocial.activerecord.backend.transaction import (
     AsyncTransactionManager,
     IsolationLevel,
+    IsolationLevelError,
 )
 
 if TYPE_CHECKING:
@@ -20,11 +23,95 @@ if TYPE_CHECKING:
 class AsyncMySQLTransactionManager(AsyncTransactionManager):
     """Asynchronous transaction manager for MySQL backend.
 
-    All transaction operations are delegated to the base class
-    which uses backend.execute() for SQL execution.
+    MySQL requires SET TRANSACTION ISOLATION LEVEL to be executed before
+    START TRANSACTION when a specific isolation level is needed. This class
+    overrides _do_begin() to handle this sequencing.
+
+    The format_begin_transaction() in MySQLDialect returns only "START TRANSACTION",
+    while this class handles the SET TRANSACTION step separately.
     """
 
+    # Isolation level mapping for MySQL
+    _ISOLATION_LEVELS = {
+        IsolationLevel.READ_UNCOMMITTED: "READ UNCOMMITTED",
+        IsolationLevel.READ_COMMITTED: "READ COMMITTED",
+        IsolationLevel.REPEATABLE_READ: "REPEATABLE READ",
+        IsolationLevel.SERIALIZABLE: "SERIALIZABLE",
+    }
+
     def __init__(self, backend: "AsyncMySQLBackend", logger=None):
+        """Initialize async MySQL transaction manager.
+
+        Args:
+            backend: AsyncMySQLBackend instance.
+            logger: Optional logger instance.
+        """
         super().__init__(backend, logger)
         # MySQL default isolation level is REPEATABLE READ
         self._isolation_level = IsolationLevel.REPEATABLE_READ
+
+    @property
+    def isolation_level(self) -> Optional[IsolationLevel]:
+        """Get the current transaction isolation level."""
+        return self._isolation_level
+
+    @isolation_level.setter
+    def isolation_level(self, level: Optional[IsolationLevel]):
+        """Set the transaction isolation level.
+
+        Note: In MySQL, isolation level can only be set before transaction starts.
+        This setter only updates the internal state. The actual SET TRANSACTION
+        statement is executed in _do_begin().
+
+        Args:
+            level: The isolation level to be set
+
+        Raises:
+            IsolationLevelError: If attempting to change isolation level while
+                                 transaction is active
+        """
+        self.log(logging.DEBUG, f"Setting isolation level to {level}")
+
+        if self.is_active:
+            self.log(logging.ERROR, "Cannot change isolation level during active transaction")
+            raise IsolationLevelError("Cannot change isolation level during active transaction")
+
+        self._isolation_level = level
+        self.log(logging.INFO, f"Isolation level set to {level}")
+
+    def _build_set_isolation_sql(self, level: IsolationLevel) -> Tuple[str, tuple]:
+        """Build SET TRANSACTION ISOLATION LEVEL SQL statement.
+
+        Args:
+            level: The isolation level to set.
+
+        Returns:
+            Tuple of (SQL string, parameters tuple).
+
+        Raises:
+            IsolationLevelError: If the isolation level is not supported.
+        """
+        level_str = self._ISOLATION_LEVELS.get(level)
+        if not level_str:
+            raise IsolationLevelError(f"Unsupported isolation level: {level}")
+        return f"SET TRANSACTION ISOLATION LEVEL {level_str}", ()
+
+    async def _do_begin(self) -> None:
+        """Begin a new transaction with MySQL-specific sequencing.
+
+        MySQL requires:
+        1. SET TRANSACTION ISOLATION LEVEL (if needed, before START)
+        2. START TRANSACTION [READ ONLY]
+
+        Each statement is executed separately via backend.execute().
+        """
+        # Step 1: Set isolation level if needed
+        if self._isolation_level is not None:
+            sql, params = self._build_set_isolation_sql(self._isolation_level)
+            self.log(logging.DEBUG, f"Executing: {sql}")
+            await self._backend.execute(sql, params)
+
+        # Step 2: Execute START TRANSACTION
+        sql, params = self._build_begin_sql()
+        self.log(logging.DEBUG, f"Executing: {sql}")
+        await self._backend.execute(sql, params)

--- a/src/rhosocial/activerecord/backend/impl/mysql/async_transaction.py
+++ b/src/rhosocial/activerecord/backend/impl/mysql/async_transaction.py
@@ -2,119 +2,29 @@
 """
 Asynchronous transaction management for MySQL backend.
 
-This module provides async transaction management capabilities for MySQL,
-including savepoints and proper isolation level handling.
+This module provides async transaction management capabilities for MySQL.
+All transaction operations are delegated to the base class
+which uses backend.execute() for SQL execution.
 """
-import logging
+from typing import TYPE_CHECKING
 
 from rhosocial.activerecord.backend.transaction import (
     AsyncTransactionManager,
     IsolationLevel,
-    TransactionState,
-    TransactionError,
 )
-from .mixins import MySQLTransactionMixin
+
+if TYPE_CHECKING:
+    from .backend import AsyncMySQLBackend
 
 
-class AsyncMySQLTransactionManager(MySQLTransactionMixin, AsyncTransactionManager):
-    """Asynchronous transaction manager for MySQL backend."""
+class AsyncMySQLTransactionManager(AsyncTransactionManager):
+    """Asynchronous transaction manager for MySQL backend.
 
-    _ISOLATION_LEVELS = MySQLTransactionMixin._ISOLATION_LEVELS
+    All transaction operations are delegated to the base class
+    which uses backend.execute() for SQL execution.
+    """
 
-    def __init__(self, connection, logger=None):
-        """Initialize async MySQL transaction manager."""
-        super().__init__(connection, logger)
-        self._savepoint_counter = 0
+    def __init__(self, backend: "AsyncMySQLBackend", logger=None):
+        super().__init__(backend, logger)
+        # MySQL default isolation level is REPEATABLE READ
         self._isolation_level = IsolationLevel.REPEATABLE_READ
-        self._state = TransactionState.INACTIVE
-
-    async def _ensure_connection_ready(self):
-        """Ensure connection is ready for transaction operations asynchronously."""
-        # For MySQL, we need to check if the connection exists and is valid
-        if not self._connection:
-            error_msg = "No valid connection for transaction"
-            self.log(logging.ERROR, error_msg)
-            raise TransactionError(error_msg)
-
-        # Check if the connection is still alive
-        try:
-            # Use ping to check connection health
-            await self._connection.ping(reconnect=False)
-        except Exception:
-            error_msg = "Connection is not active"
-            self.log(logging.ERROR, error_msg)
-            raise TransactionError(error_msg) from None
-
-    async def _do_begin(self) -> None:
-        """Begin a new transaction"""
-        # Set isolation level if specified
-        if self._isolation_level:
-            isolation_map = {
-                IsolationLevel.READ_UNCOMMITTED: "READ UNCOMMITTED",
-                IsolationLevel.READ_COMMITTED: "READ COMMITTED",
-                IsolationLevel.REPEATABLE_READ: "REPEATABLE READ",
-                IsolationLevel.SERIALIZABLE: "SERIALIZABLE"
-            }
-            isolation_str = isolation_map.get(self._isolation_level)
-            if isolation_str:
-                await self._execute_sql(f"SET TRANSACTION ISOLATION LEVEL {isolation_str}")
-
-        # Start transaction
-        await self._execute_sql("START TRANSACTION")
-        self.log(logging.INFO, f"Started transaction with isolation level: {self._isolation_level or 'DEFAULT'}")
-
-    async def _do_commit(self) -> None:
-        """Commit the current transaction"""
-        await self._execute_sql("COMMIT")
-        self.log(logging.INFO, "Transaction committed successfully")
-
-    async def _do_rollback(self) -> None:
-        """Rollback the current transaction"""
-        await self._execute_sql("ROLLBACK")
-        self.log(logging.INFO, "Transaction rolled back successfully")
-
-    async def _do_create_savepoint(self, name: str) -> None:
-        """Create a savepoint"""
-        await self._execute_sql(f"SAVEPOINT {name}")
-        self.log(logging.INFO, f"Created savepoint: {name}")
-
-    async def _do_release_savepoint(self, name: str) -> None:
-        """Release a savepoint"""
-        await self._execute_sql(f"RELEASE SAVEPOINT {name}")
-        self.log(logging.INFO, f"Released savepoint: {name}")
-
-    async def _do_rollback_savepoint(self, name: str) -> None:
-        """Rollback to a specified savepoint"""
-        await self._execute_sql(f"ROLLBACK TO SAVEPOINT {name}")
-        self.log(logging.INFO, f"Rolled back to savepoint: {name}")
-
-    async def supports_savepoint(self) -> bool:
-        """Check if savepoints are supported"""
-        # MySQL supports savepoints since version 4.0.14
-        try:
-            version = await self.backend.get_server_version()
-            # Savepoints are supported in MySQL 4.0.14 and later
-            return version >= (4, 0, 14)
-        except Exception:
-            # If we can't determine the version, assume savepoints are supported
-            return True
-
-    # The base class AsyncTransactionManager provides the public interface methods
-    # (begin, commit, rollback, create_savepoint, etc.) which delegate to the
-    # abstract methods (_do_begin, _do_commit, etc.) that we've implemented above.
-    # So we don't need to reimplement these methods here.
-
-    async def _execute_sql(self, sql: str) -> None:
-        """Execute a raw SQL statement using the connection."""
-        # Use the connection directly
-        cursor = await self._connection.cursor()
-        await cursor.execute(sql)
-        await cursor.close()
-
-    def log(self, level: int, message: str):
-        """Log a message with the specified level."""
-        if hasattr(self, '_logger') and self._logger:
-            self._logger.log(level, message)
-        else:
-            # Fallback logging
-            print(f"[TRANSACTION] {message}")

--- a/src/rhosocial/activerecord/backend/impl/mysql/async_transaction.py
+++ b/src/rhosocial/activerecord/backend/impl/mysql/async_transaction.py
@@ -47,8 +47,9 @@ class AsyncMySQLTransactionManager(AsyncTransactionManager):
             logger: Optional logger instance.
         """
         super().__init__(backend, logger)
-        # MySQL default isolation level is REPEATABLE READ
-        self._isolation_level = IsolationLevel.REPEATABLE_READ
+        # Note: _isolation_level defaults to None (use database default).
+        # MySQL's default isolation level is REPEATABLE READ, but we only
+        # send SET TRANSACTION when user explicitly specifies a level.
 
     @property
     def isolation_level(self) -> Optional[IsolationLevel]:

--- a/src/rhosocial/activerecord/backend/impl/mysql/backend.py
+++ b/src/rhosocial/activerecord/backend/impl/mysql/backend.py
@@ -95,9 +95,8 @@ class MySQLBackend(SyncExplainBackendMixin, IntrospectorBackendMixin, MySQLBacke
         self._version = version or (8, 0, 0)
         # Initialize MySQL-specific components (lazy load dialect)
         self._dialect = None
-        # Initialize transaction manager with connection (will be set when connected)
-        # Pass None for connection initially, it will be updated later
-        self._transaction_manager = MySQLTransactionManager(None, self.logger)
+        # Initialize transaction manager (will use backend.execute())
+        self._transaction_manager = MySQLTransactionManager(self, self.logger)
 
         # Register MySQL-specific type adapters (uses self._version)
         self._register_mysql_adapters()

--- a/src/rhosocial/activerecord/backend/impl/mysql/dialect.py
+++ b/src/rhosocial/activerecord/backend/impl/mysql/dialect.py
@@ -1010,6 +1010,56 @@ class MySQLDialect(
         """MySQL supports savepoints."""
         return True
 
+    def format_set_transaction(
+        self, expr: "SetTransactionExpression"
+    ) -> Tuple[str, tuple]:
+        """Format SET TRANSACTION statement for MySQL.
+
+        MySQL requires SET TRANSACTION ISOLATION LEVEL to be executed before
+        START TRANSACTION when a specific isolation level is needed. This method
+        generates the appropriate SET TRANSACTION statement.
+
+        Args:
+            expr: SetTransactionExpression with isolation level and/or mode.
+
+        Returns:
+            Tuple of (SQL string, parameters tuple).
+
+        Note:
+            This statement must be executed before START TRANSACTION.
+            The MySQLTransactionManager._do_begin() handles this sequencing.
+        """
+        from rhosocial.activerecord.backend.transaction import IsolationLevel, TransactionMode
+
+        params = expr.get_params()
+        parts = []
+
+        # Handle isolation level
+        isolation_level = params.get("isolation_level")
+        if isolation_level is not None:
+            level_names = {
+                IsolationLevel.READ_UNCOMMITTED: "READ UNCOMMITTED",
+                IsolationLevel.READ_COMMITTED: "READ COMMITTED",
+                IsolationLevel.REPEATABLE_READ: "REPEATABLE READ",
+                IsolationLevel.SERIALIZABLE: "SERIALIZABLE",
+            }
+            level_name = level_names.get(isolation_level)
+            if level_name:
+                parts.append(f"ISOLATION LEVEL {level_name}")
+
+        # Handle transaction mode (READ ONLY/READ WRITE)
+        mode = params.get("mode")
+        if mode is not None:
+            if mode == TransactionMode.READ_ONLY:
+                parts.append("READ ONLY")
+            elif mode == TransactionMode.READ_WRITE:
+                parts.append("READ WRITE")
+
+        if not parts:
+            return "SET TRANSACTION", ()
+
+        return f"SET TRANSACTION {' '.join(parts)}", ()
+
     def format_begin_transaction(
         self, expr: "BeginTransactionExpression"
     ) -> Tuple[str, tuple]:

--- a/src/rhosocial/activerecord/backend/impl/mysql/dialect.py
+++ b/src/rhosocial/activerecord/backend/impl/mysql/dialect.py
@@ -33,6 +33,8 @@ from rhosocial.activerecord.backend.dialect.protocols import (
     SequenceSupport,
     TableSupport,
     IntrospectionSupport,
+    # Transaction Control Protocol
+    TransactionControlSupport,
 )
 from rhosocial.activerecord.backend.dialect.mixins import (
     CTEMixin,
@@ -147,6 +149,8 @@ class MySQLDialect(
     SequenceSupport,
     TableSupport,
     IntrospectionSupport,
+    # Transaction Control Protocol
+    TransactionControlSupport,
     # MySQL-specific protocols
     MySQLTriggerSupport,
     MySQLTableSupport,
@@ -979,4 +983,85 @@ class MySQLDialect(
         MySQL 8.0+ supports expressions in DEFAULT column values.
         """
         return self.version >= (8, 0, 0)
+    # endregion
+
+    # region Transaction Control
+
+    def supports_transaction_mode(self) -> bool:
+        """MySQL supports READ ONLY transactions (5.6.5+)."""
+        return self.version >= (5, 6, 5)
+
+    def supports_isolation_level_in_begin(self) -> bool:
+        """MySQL does not support isolation level in START TRANSACTION.
+
+        MySQL uses SET TRANSACTION ISOLATION LEVEL before START TRANSACTION.
+        """
+        return False
+
+    def supports_read_only_transaction(self) -> bool:
+        """MySQL supports READ ONLY transactions (5.6.5+)."""
+        return self.version >= (5, 6, 5)
+
+    def supports_deferrable_transaction(self) -> bool:
+        """MySQL does not support DEFERRABLE mode."""
+        return False
+
+    def supports_savepoint(self) -> bool:
+        """MySQL supports savepoints."""
+        return True
+
+    def format_begin_transaction(
+        self, expr: "BeginTransactionExpression"
+    ) -> Tuple[str, tuple]:
+        """Format START TRANSACTION statement for MySQL.
+
+        MySQL requires:
+        1. SET TRANSACTION ISOLATION LEVEL (if needed, before START)
+        2. START TRANSACTION [READ ONLY] (MySQL 5.6.5+)
+
+        Note: Returns multiple statements separated by semicolon.
+
+        Args:
+            expr: BeginTransactionExpression with isolation level and mode.
+
+        Returns:
+            Tuple of (SQL string, parameters tuple).
+        """
+        from rhosocial.activerecord.backend.transaction import IsolationLevel, TransactionMode
+
+        params = expr.get_params()
+        statements = []
+
+        # Isolation level mapping for MySQL
+        isolation_levels = {
+            IsolationLevel.READ_UNCOMMITTED: "READ UNCOMMITTED",
+            IsolationLevel.READ_COMMITTED: "READ COMMITTED",
+            IsolationLevel.REPEATABLE_READ: "REPEATABLE READ",
+            IsolationLevel.SERIALIZABLE: "SERIALIZABLE",
+        }
+
+        # Set isolation level if specified (must be before START TRANSACTION)
+        isolation = params.get("isolation_level")
+        if isolation:
+            level_str = isolation_levels.get(isolation)
+            if level_str:
+                statements.append(f"SET TRANSACTION ISOLATION LEVEL {level_str}")
+
+        # Build START TRANSACTION
+        mode = params.get("mode")
+        if mode == TransactionMode.READ_ONLY:
+            if self.supports_read_only_transaction():
+                statements.append("START TRANSACTION READ ONLY")
+            else:
+                from rhosocial.activerecord.backend.errors import UnsupportedTransactionModeError
+                raise UnsupportedTransactionModeError(
+                    feature="READ ONLY transactions",
+                    backend="MySQL",
+                    message="READ ONLY transactions require MySQL 5.6.5 or later."
+                )
+        else:
+            statements.append("START TRANSACTION")
+
+        return "; ".join(statements), ()
+
     # endregion

--- a/src/rhosocial/activerecord/backend/impl/mysql/dialect.py
+++ b/src/rhosocial/activerecord/backend/impl/mysql/dialect.py
@@ -1015,43 +1015,30 @@ class MySQLDialect(
     ) -> Tuple[str, tuple]:
         """Format START TRANSACTION statement for MySQL.
 
-        MySQL requires:
-        1. SET TRANSACTION ISOLATION LEVEL (if needed, before START)
-        2. START TRANSACTION [READ ONLY] (MySQL 5.6.5+)
-
-        Note: Returns multiple statements separated by semicolon.
+        This method returns a SINGLE SQL statement as required by the protocol.
+        For MySQL, isolation level must be set separately using SET TRANSACTION
+        before START TRANSACTION. The TransactionManager handles this sequencing.
 
         Args:
             expr: BeginTransactionExpression with isolation level and mode.
 
         Returns:
             Tuple of (SQL string, parameters tuple).
+
+        Note:
+            Isolation level is NOT included in this statement. Use
+            format_set_transaction() for that purpose, which should be called
+            before this method by MySQLTransactionManager._do_begin().
         """
-        from rhosocial.activerecord.backend.transaction import IsolationLevel, TransactionMode
+        from rhosocial.activerecord.backend.transaction import TransactionMode
 
         params = expr.get_params()
-        statements = []
 
-        # Isolation level mapping for MySQL
-        isolation_levels = {
-            IsolationLevel.READ_UNCOMMITTED: "READ UNCOMMITTED",
-            IsolationLevel.READ_COMMITTED: "READ COMMITTED",
-            IsolationLevel.REPEATABLE_READ: "REPEATABLE READ",
-            IsolationLevel.SERIALIZABLE: "SERIALIZABLE",
-        }
-
-        # Set isolation level if specified (must be before START TRANSACTION)
-        isolation = params.get("isolation_level")
-        if isolation:
-            level_str = isolation_levels.get(isolation)
-            if level_str:
-                statements.append(f"SET TRANSACTION ISOLATION LEVEL {level_str}")
-
-        # Build START TRANSACTION
+        # Build START TRANSACTION (without isolation level)
         mode = params.get("mode")
         if mode == TransactionMode.READ_ONLY:
             if self.supports_read_only_transaction():
-                statements.append("START TRANSACTION READ ONLY")
+                return "START TRANSACTION READ ONLY", ()
             else:
                 from rhosocial.activerecord.backend.errors import UnsupportedTransactionModeError
                 raise UnsupportedTransactionModeError(
@@ -1060,8 +1047,6 @@ class MySQLDialect(
                     message="READ ONLY transactions require MySQL 5.6.5 or later."
                 )
         else:
-            statements.append("START TRANSACTION")
-
-        return "; ".join(statements), ()
+            return "START TRANSACTION", ()
 
     # endregion

--- a/src/rhosocial/activerecord/backend/impl/mysql/mixins.py
+++ b/src/rhosocial/activerecord/backend/impl/mysql/mixins.py
@@ -425,9 +425,6 @@ class MySQLBackendMixin:
     @property
     def transaction_manager(self):
         """Get the MySQL transaction manager."""
-        # Update the transaction manager's connection if needed
-        if self._transaction_manager:
-            self._transaction_manager._connection = self._connection
         return self._transaction_manager
 
     def requires_manual_commit(self) -> bool:

--- a/src/rhosocial/activerecord/backend/impl/mysql/transaction.py
+++ b/src/rhosocial/activerecord/backend/impl/mysql/transaction.py
@@ -1,13 +1,15 @@
 # src/rhosocial/activerecord/backend/impl/mysql/transaction.py
 """MySQL synchronous transaction manager implementation.
 
-This module provides a simplified MySQL transaction manager that uses
-the base TransactionManager for all operations via backend.execute().
+This module provides MySQL-specific transaction management that handles
+MySQL's requirement for SET TRANSACTION before START TRANSACTION.
 """
-from typing import TYPE_CHECKING
+import logging
+from typing import TYPE_CHECKING, Optional, Tuple
 
 from rhosocial.activerecord.backend.transaction import (
     IsolationLevel,
+    IsolationLevelError,
     TransactionManager,
 )
 
@@ -18,9 +20,21 @@ if TYPE_CHECKING:
 class MySQLTransactionManager(TransactionManager):
     """MySQL synchronous transaction manager implementation.
 
-    All transaction operations are delegated to the base class
-    which uses backend.execute() for SQL execution.
+    MySQL requires SET TRANSACTION ISOLATION LEVEL to be executed before
+    START TRANSACTION when a specific isolation level is needed. This class
+    overrides _do_begin() to handle this sequencing.
+
+    The format_begin_transaction() in MySQLDialect returns only "START TRANSACTION",
+    while this class handles the SET TRANSACTION step separately.
     """
+
+    # Isolation level mapping for MySQL
+    _ISOLATION_LEVELS = {
+        IsolationLevel.READ_UNCOMMITTED: "READ UNCOMMITTED",
+        IsolationLevel.READ_COMMITTED: "READ COMMITTED",
+        IsolationLevel.REPEATABLE_READ: "REPEATABLE READ",
+        IsolationLevel.SERIALIZABLE: "SERIALIZABLE",
+    }
 
     def __init__(self, backend: "MySQLBackend", logger=None):
         """Initialize MySQL transaction manager.
@@ -32,3 +46,69 @@ class MySQLTransactionManager(TransactionManager):
         super().__init__(backend, logger)
         # MySQL default isolation level is REPEATABLE READ
         self._isolation_level = IsolationLevel.REPEATABLE_READ
+
+    @property
+    def isolation_level(self) -> Optional[IsolationLevel]:
+        """Get the current transaction isolation level."""
+        return self._isolation_level
+
+    @isolation_level.setter
+    def isolation_level(self, level: Optional[IsolationLevel]):
+        """Set the transaction isolation level.
+
+        Note: In MySQL, isolation level can only be set before transaction starts.
+        This setter only updates the internal state. The actual SET TRANSACTION
+        statement is executed in _do_begin().
+
+        Args:
+            level: The isolation level to be set
+
+        Raises:
+            IsolationLevelError: If attempting to change isolation level while
+                                 transaction is active
+        """
+        self.log(logging.DEBUG, f"Setting isolation level to {level}")
+
+        if self.is_active:
+            self.log(logging.ERROR, "Cannot change isolation level during active transaction")
+            raise IsolationLevelError("Cannot change isolation level during active transaction")
+
+        self._isolation_level = level
+        self.log(logging.INFO, f"Isolation level set to {level}")
+
+    def _build_set_isolation_sql(self, level: IsolationLevel) -> Tuple[str, tuple]:
+        """Build SET TRANSACTION ISOLATION LEVEL SQL statement.
+
+        Args:
+            level: The isolation level to set.
+
+        Returns:
+            Tuple of (SQL string, parameters tuple).
+
+        Raises:
+            IsolationLevelError: If the isolation level is not supported.
+        """
+        level_str = self._ISOLATION_LEVELS.get(level)
+        if not level_str:
+            raise IsolationLevelError(f"Unsupported isolation level: {level}")
+        return f"SET TRANSACTION ISOLATION LEVEL {level_str}", ()
+
+    def _do_begin(self) -> None:
+        """Begin a new transaction with MySQL-specific sequencing.
+
+        MySQL requires:
+        1. SET TRANSACTION ISOLATION LEVEL (if needed, before START)
+        2. START TRANSACTION [READ ONLY]
+
+        Each statement is executed separately via backend.execute().
+        """
+        # Step 1: Set isolation level if needed
+        if self._isolation_level is not None:
+            sql, params = self._build_set_isolation_sql(self._isolation_level)
+            self.log(logging.DEBUG, f"Executing: {sql}")
+            self._backend.execute(sql, params)
+
+        # Step 2: Execute START TRANSACTION
+        sql, params = self._build_begin_sql()
+        self.log(logging.DEBUG, f"Executing: {sql}")
+        self._backend.execute(sql, params)

--- a/src/rhosocial/activerecord/backend/impl/mysql/transaction.py
+++ b/src/rhosocial/activerecord/backend/impl/mysql/transaction.py
@@ -1,150 +1,34 @@
 # src/rhosocial/activerecord/backend/impl/mysql/transaction.py
-"""MySQL synchronous transaction manager implementation."""
-import logging
-from mysql.connector.errors import Error as MySQLError, ProgrammingError
+"""MySQL synchronous transaction manager implementation.
 
-from rhosocial.activerecord.backend.errors import TransactionError
+This module provides a simplified MySQL transaction manager that uses
+the base TransactionManager for all operations via backend.execute().
+"""
+from typing import TYPE_CHECKING
+
 from rhosocial.activerecord.backend.transaction import (
     IsolationLevel,
     TransactionManager,
-    TransactionState,
 )
-from .mixins import MySQLTransactionMixin
+
+if TYPE_CHECKING:
+    from .backend import MySQLBackend
 
 
-class MySQLTransactionManager(MySQLTransactionMixin, TransactionManager):
-    """MySQL synchronous transaction manager implementation."""
+class MySQLTransactionManager(TransactionManager):
+    """MySQL synchronous transaction manager implementation.
 
-    _ISOLATION_LEVELS = MySQLTransactionMixin._ISOLATION_LEVELS
+    All transaction operations are delegated to the base class
+    which uses backend.execute() for SQL execution.
+    """
 
-    def __init__(self, connection, logger=None):
-        """Initialize MySQL transaction manager."""
-        super().__init__(connection, logger)
+    def __init__(self, backend: "MySQLBackend", logger=None):
+        """Initialize MySQL transaction manager.
+
+        Args:
+            backend: MySQLBackend instance.
+            logger: Optional logger instance.
+        """
+        super().__init__(backend, logger)
+        # MySQL default isolation level is REPEATABLE READ
         self._isolation_level = IsolationLevel.REPEATABLE_READ
-        self._state = TransactionState.INACTIVE
-
-    def _ensure_connection_ready(self):
-        """Ensure connection is ready for transaction operations."""
-        # For MySQL, we need to check if the connection exists and is valid
-        # The base TransactionManager class has a _backend reference that we can use
-        if not self._connection:
-            error_msg = "No valid connection for transaction"
-            self.log(logging.ERROR, error_msg)
-            raise TransactionError(error_msg)
-
-        # Check if the connection is still alive
-        try:
-            # Use ping to check connection health
-            self._connection.ping(reconnect=False)
-        except MySQLError:
-            error_msg = "Connection is not active"
-            self.log(logging.ERROR, error_msg)
-            raise TransactionError(error_msg) from None
-
-    def _do_begin(self) -> None:
-        """Begin MySQL transaction."""
-        self._ensure_connection_ready()
-
-        try:
-            isolation_string = self._ISOLATION_LEVELS.get(self._isolation_level)
-
-            cursor = self._connection.cursor()
-            cursor.execute("SELECT @@autocommit")
-            auto_commit = cursor.fetchone()[0]
-            cursor.close()
-
-            if auto_commit == 0 and self._transaction_level == 0:
-                self.log(logging.WARNING, "Found existing transaction, attempting to rollback")
-                try:
-                    self._connection.rollback()
-                except MySQLError:
-                    pass
-
-            self._connection.start_transaction(isolation_level=isolation_string)
-            self._state = TransactionState.ACTIVE
-
-            self.log(logging.DEBUG, f"Started MySQL transaction with isolation level {isolation_string}")
-        except ProgrammingError as e:
-            if "Transaction already in progress" in str(e) and self._transaction_level == 0:
-                self.log(logging.WARNING, "Transaction already in progress at server level")
-                self._state = TransactionState.ACTIVE
-            else:
-                error_msg = f"Failed to begin transaction: {str(e)}"
-                self.log(logging.ERROR, error_msg)
-                raise TransactionError(error_msg) from e
-        except MySQLError as e:
-            error_msg = f"Failed to begin transaction: {str(e)}"
-            self.log(logging.ERROR, error_msg)
-            raise TransactionError(error_msg) from e
-
-    def _do_commit(self) -> None:
-        """Commit MySQL transaction."""
-        self._ensure_connection_ready()
-
-        try:
-            self._connection.commit()
-            self._state = TransactionState.COMMITTED
-            self.log(logging.DEBUG, "Committed MySQL transaction")
-        except MySQLError as e:
-            error_msg = f"Failed to commit transaction: {str(e)}"
-            self.log(logging.ERROR, error_msg)
-            raise TransactionError(error_msg) from e
-
-    def _do_rollback(self) -> None:
-        """Rollback MySQL transaction."""
-        self._ensure_connection_ready()
-
-        try:
-            self._connection.rollback()
-            self._state = TransactionState.ROLLED_BACK
-            self.log(logging.DEBUG, "Rolled back MySQL transaction")
-        except MySQLError as e:
-            error_msg = f"Failed to rollback transaction: {str(e)}"
-            self.log(logging.ERROR, error_msg)
-            raise TransactionError(error_msg) from e
-
-    def _do_create_savepoint(self, name: str) -> None:
-        """Create MySQL savepoint."""
-        self._ensure_connection_ready()
-
-        try:
-            cursor = self._connection.cursor()
-            cursor.execute(f"SAVEPOINT {name}")
-            cursor.close()
-            self.log(logging.DEBUG, f"Created savepoint: {name}")
-        except MySQLError as e:
-            error_msg = f"Failed to create savepoint {name}: {str(e)}"
-            self.log(logging.ERROR, error_msg)
-            raise TransactionError(error_msg) from e
-
-    def _do_release_savepoint(self, name: str) -> None:
-        """Release MySQL savepoint."""
-        self._ensure_connection_ready()
-
-        try:
-            cursor = self._connection.cursor()
-            cursor.execute(f"RELEASE SAVEPOINT {name}")
-            cursor.close()
-            self.log(logging.DEBUG, f"Released savepoint: {name}")
-        except MySQLError as e:
-            error_msg = f"Failed to release savepoint {name}: {str(e)}"
-            self.log(logging.ERROR, error_msg)
-            raise TransactionError(error_msg) from e
-
-    def _do_rollback_savepoint(self, name: str) -> None:
-        """Rollback to MySQL savepoint."""
-        self._ensure_connection_ready()
-
-        try:
-            cursor = self._connection.cursor()
-            cursor.execute(f"ROLLBACK TO SAVEPOINT {name}")
-            cursor.close()
-            self.log(logging.DEBUG, f"Rolled back to savepoint: {name}")
-        except MySQLError as e:
-            error_msg = f"Failed to rollback to savepoint {name}: {str(e)}"
-            self.log(logging.ERROR, error_msg)
-            raise TransactionError(error_msg) from e
-
-    def supports_savepoint(self) -> bool:
-        """Check if savepoints are supported."""
-        return True

--- a/src/rhosocial/activerecord/backend/impl/mysql/transaction.py
+++ b/src/rhosocial/activerecord/backend/impl/mysql/transaction.py
@@ -44,8 +44,9 @@ class MySQLTransactionManager(TransactionManager):
             logger: Optional logger instance.
         """
         super().__init__(backend, logger)
-        # MySQL default isolation level is REPEATABLE READ
-        self._isolation_level = IsolationLevel.REPEATABLE_READ
+        # Note: _isolation_level defaults to None (use database default).
+        # MySQL's default isolation level is REPEATABLE READ, but we only
+        # send SET TRANSACTION when user explicitly specifies a level.
 
     @property
     def isolation_level(self) -> Optional[IsolationLevel]:

--- a/tests/rhosocial/activerecord_mysql_test/feature/backend/test_async_transaction_isolation_effect.py
+++ b/tests/rhosocial/activerecord_mysql_test/feature/backend/test_async_transaction_isolation_effect.py
@@ -379,6 +379,104 @@ class TestAsyncTransactionCombination:
                 assert "REPEATABLE READ" in isolation.upper() or "REPEATABLE-READ" in isolation.upper()
 
     @pytest.mark.asyncio
+    async def test_no_isolation_level_set_uses_database_default(self, async_mysql_backend):
+        """Verify that when no isolation level is set, no SET TRANSACTION is sent (async).
+
+        This tests that:
+        1. The initial isolation_level is None (not REPEATABLE_READ)
+        2. No SET TRANSACTION statement is sent when user doesn't specify isolation
+        3. MySQL uses its default isolation level (REPEATABLE READ)
+        """
+        from unittest.mock import patch
+
+        # Verify initial state is None
+        assert async_mysql_backend.transaction_manager._isolation_level is None, \
+            "Initial isolation level should be None (use database default)"
+
+        # Track SQL statements executed
+        executed_statements = []
+        original_execute = async_mysql_backend.execute
+
+        async def track_execute(sql, params=None, **kwargs):
+            executed_statements.append(sql)
+            return await original_execute(sql, params, **kwargs)
+
+        # Patch execute to track statements
+        with patch.object(async_mysql_backend, 'execute', side_effect=track_execute):
+            async with async_mysql_backend.transaction():
+                # Execute a simple query inside the transaction
+                await async_mysql_backend.fetch_all("SELECT 1 as test")
+
+        # Verify no SET TRANSACTION was sent
+        set_transaction_found = any(
+            'SET TRANSACTION' in stmt.upper() for stmt in executed_statements
+        )
+        assert not set_transaction_found, \
+            f"SET TRANSACTION should NOT be sent when isolation level not specified. Executed: {executed_statements}"
+
+        # Verify START TRANSACTION was sent
+        start_transaction_found = any(
+            'START TRANSACTION' in stmt.upper() for stmt in executed_statements
+        )
+        assert start_transaction_found, \
+            f"START TRANSACTION should be sent. Executed: {executed_statements}"
+
+    @pytest.mark.asyncio
+    async def test_explicit_isolation_level_sends_set_transaction(self, async_mysql_backend):
+        """Verify that when isolation level is explicitly set, SET TRANSACTION is sent (async).
+
+        This tests that:
+        1. Setting isolation_level property changes the internal state
+        2. SET TRANSACTION statement is sent before START TRANSACTION
+        3. The correct isolation level is used
+        """
+        from unittest.mock import patch
+
+        # Set isolation level explicitly
+        async_mysql_backend.transaction_manager.isolation_level = IsolationLevel.READ_COMMITTED
+
+        # Verify internal state changed
+        assert async_mysql_backend.transaction_manager._isolation_level == IsolationLevel.READ_COMMITTED, \
+            "Isolation level should be READ_COMMITTED after explicit setting"
+
+        # Track SQL statements executed
+        executed_statements = []
+        original_execute = async_mysql_backend.execute
+
+        async def track_execute(sql, params=None, **kwargs):
+            executed_statements.append(sql)
+            return await original_execute(sql, params, **kwargs)
+
+        # Patch execute to track statements
+        with patch.object(async_mysql_backend, 'execute', side_effect=track_execute):
+            async with async_mysql_backend.transaction():
+                await async_mysql_backend.fetch_all("SELECT 1 as test")
+
+        # Verify SET TRANSACTION was sent with correct level
+        set_transaction_found = any(
+            'SET TRANSACTION' in stmt.upper() and 'READ COMMITTED' in stmt.upper()
+            for stmt in executed_statements
+        )
+        assert set_transaction_found, \
+            f"SET TRANSACTION READ COMMITTED should be sent. Executed: {executed_statements}"
+
+        # Verify SET TRANSACTION comes before START TRANSACTION
+        set_transaction_idx = next(
+            (i for i, stmt in enumerate(executed_statements)
+             if 'SET TRANSACTION' in stmt.upper()),
+            None
+        )
+        start_transaction_idx = next(
+            (i for i, stmt in enumerate(executed_statements)
+             if 'START TRANSACTION' in stmt.upper()),
+            None
+        )
+        assert set_transaction_idx is not None and start_transaction_idx is not None, \
+            "Both SET TRANSACTION and START TRANSACTION should be executed"
+        assert set_transaction_idx < start_transaction_idx, \
+            f"SET TRANSACTION should come before START TRANSACTION. Order: {executed_statements}"
+
+    @pytest.mark.asyncio
     async def test_isolation_level_cannot_change_during_transaction(self, async_mysql_backend, async_isolation_test_table):
         """Verify isolation level cannot be changed during active transaction (async)."""
         async with async_mysql_backend.transaction():

--- a/tests/rhosocial/activerecord_mysql_test/feature/backend/test_async_transaction_isolation_effect.py
+++ b/tests/rhosocial/activerecord_mysql_test/feature/backend/test_async_transaction_isolation_effect.py
@@ -365,9 +365,14 @@ class TestAsyncTransactionCombination:
     @pytest.mark.asyncio
     async def test_default_isolation_is_repeatable_read(self, async_mysql_backend):
         """Verify MySQL default isolation level is REPEATABLE READ (async)."""
+        # MySQL 5.6 uses @@tx_isolation, MySQL 5.7+ uses @@transaction_isolation
+        # Detect version and use appropriate variable
+        version = async_mysql_backend.dialect.get_server_version()
+        isolation_var = "@@transaction_isolation" if version >= (5, 7, 0) else "@@tx_isolation"
+
         async with async_mysql_backend.transaction():
             rows = await async_mysql_backend.fetch_all(
-                "select @@transaction_isolation as isolation"
+                f"SELECT {isolation_var} as isolation"
             )
             if rows and rows[0].get("isolation"):
                 isolation = rows[0]["isolation"]

--- a/tests/rhosocial/activerecord_mysql_test/feature/backend/test_async_transaction_isolation_effect.py
+++ b/tests/rhosocial/activerecord_mysql_test/feature/backend/test_async_transaction_isolation_effect.py
@@ -1,0 +1,409 @@
+# tests/rhosocial/activerecord_mysql_test/feature/backend/test_async_transaction_isolation_effect.py
+"""
+Async tests for MySQL transaction isolation level and mode effects.
+
+This module tests the actual behavior of different isolation levels and transaction modes
+with MySQL backend using async operations.
+"""
+import pytest
+import pytest_asyncio
+import asyncio
+from decimal import Decimal
+
+from rhosocial.activerecord.backend.impl.mysql import AsyncMySQLBackend
+from rhosocial.activerecord.backend.transaction import IsolationLevel, TransactionMode
+from rhosocial.activerecord.backend.errors import TransactionError
+
+
+@pytest_asyncio.fixture
+async def async_isolation_test_table(async_mysql_backend):
+    """Create a test table for async isolation tests."""
+    await async_mysql_backend.execute("drop table if exists async_isolation_test")
+    await async_mysql_backend.execute("""
+        create table async_isolation_test (
+            id INT AUTO_INCREMENT PRIMARY KEY,
+            name VARCHAR(255),
+            balance DECIMAL(10, 2),
+            version INT DEFAULT 1
+        )
+    """)
+    await async_mysql_backend.execute(
+        "insert into async_isolation_test (name, balance) values (%s, %s)",
+        ("user1", Decimal("100.00"))
+    )
+    yield "async_isolation_test"
+    await async_mysql_backend.execute("drop table if exists async_isolation_test")
+
+
+@pytest_asyncio.fixture
+async def async_mode_test_table(async_mysql_backend):
+    """Create a test table for transaction mode tests."""
+    await async_mysql_backend.execute("drop table if exists async_mode_test")
+    await async_mysql_backend.execute("""
+        create table async_mode_test (
+            id INT AUTO_INCREMENT PRIMARY KEY,
+            name VARCHAR(255),
+            balance DECIMAL(10, 2)
+        )
+    """)
+    await async_mysql_backend.execute(
+        "insert into async_mode_test (name, balance) values (%s, %s)",
+        ("account1", Decimal("1000.00"))
+    )
+    yield "async_mode_test"
+    await async_mysql_backend.execute("drop table if exists async_mode_test")
+
+
+@pytest_asyncio.fixture
+async def async_combo_test_table(async_mysql_backend):
+    """Create a test table for combination tests."""
+    await async_mysql_backend.execute("drop table if exists async_combo_test")
+    await async_mysql_backend.execute("""
+        create table async_combo_test (
+            id INT AUTO_INCREMENT PRIMARY KEY,
+            name VARCHAR(255),
+            balance DECIMAL(10, 2)
+        )
+    """)
+    await async_mysql_backend.execute(
+        "insert into async_combo_test (name, balance) values (%s, %s)",
+        ("account1", Decimal("1000.00"))
+    )
+    yield "async_combo_test"
+    await async_mysql_backend.execute("drop table if exists async_combo_test")
+
+
+@pytest_asyncio.fixture
+async def async_nested_test_table(async_mysql_backend):
+    """Create a test table for nested transaction tests."""
+    await async_mysql_backend.execute("drop table if exists async_nested_test")
+    await async_mysql_backend.execute("""
+        create table async_nested_test (
+            id INT AUTO_INCREMENT PRIMARY KEY,
+            name VARCHAR(255),
+            value INT
+        )
+    """)
+    yield "async_nested_test"
+    await async_mysql_backend.execute("drop table if exists async_nested_test")
+
+
+class TestAsyncIsolationLevelEffect:
+    """Test actual isolation behavior for each isolation level."""
+
+    @pytest.mark.asyncio
+    async def test_read_uncommitted_allows_dirty_reads(self, async_mysql_backend, async_mysql_control_backend, async_isolation_test_table):
+        """Verify READ UNCOMMITTED isolation level allows dirty reads (async).
+
+        A dirty read occurs when a transaction reads data written by another
+        uncommitted transaction. READ UNCOMMITTED should allow this.
+        """
+        dirty_read_detected = []
+
+        async def transaction1():
+            """Transaction 1: Read uncommitted data."""
+            try:
+                async_mysql_backend.transaction_manager.isolation_level = IsolationLevel.READ_UNCOMMITTED
+                async with async_mysql_backend.transaction():
+                    await asyncio.sleep(0.1)
+                    rows = await async_mysql_backend.fetch_all(
+                        "select balance from async_isolation_test where name = %s",
+                        ("user1",)
+                    )
+                    if rows and rows[0]["balance"] == Decimal("200.00"):
+                        dirty_read_detected.append(True)
+            except Exception as e:
+                dirty_read_detected.append(str(e))
+
+        async def transaction2():
+            """Transaction 2: Modify data without committing."""
+            try:
+                async_mysql_control_backend.transaction_manager.isolation_level = IsolationLevel.READ_UNCOMMITTED
+                async with async_mysql_control_backend.transaction():
+                    await async_mysql_control_backend.execute(
+                        "update async_isolation_test set balance = %s where name = %s",
+                        (Decimal("200.00"), "user1")
+                    )
+                    await asyncio.sleep(0.3)
+                    raise Exception("Force rollback for dirty read test")
+            except Exception:
+                pass
+
+        await asyncio.gather(transaction1(), transaction2())
+        assert True in dirty_read_detected, "READ UNCOMMITTED should allow dirty reads"
+
+    @pytest.mark.asyncio
+    async def test_read_committed_prevents_dirty_reads(self, async_mysql_backend, async_mysql_control_backend, async_isolation_test_table):
+        """Verify READ COMMITTED isolation level prevents dirty reads (async)."""
+        dirty_read_occurred = []
+
+        async def transaction1():
+            """Transaction 1: Should not see uncommitted data."""
+            try:
+                async_mysql_backend.transaction_manager.isolation_level = IsolationLevel.READ_COMMITTED
+                async with async_mysql_backend.transaction():
+                    await asyncio.sleep(0.15)
+                    rows = await async_mysql_backend.fetch_all(
+                        "select balance from async_isolation_test where name = %s",
+                        ("user1",)
+                    )
+                    if rows and rows[0]["balance"] != Decimal("200.00"):
+                        dirty_read_occurred.append(False)  # Correct behavior - no dirty read
+                    else:
+                        dirty_read_occurred.append(True)  # Dirty read happened
+            except Exception as e:
+                dirty_read_occurred.append(str(e))
+
+        async def transaction2():
+            """Transaction 2: modify data and rollback."""
+            try:
+                async_mysql_control_backend.transaction_manager.isolation_level = IsolationLevel.READ_COMMITTED
+                async with async_mysql_control_backend.transaction():
+                    await async_mysql_control_backend.execute(
+                        "update async_isolation_test set balance = %s where name = %s",
+                        (Decimal("200.00"), "user1")
+                    )
+                    await asyncio.sleep(0.2)
+                    raise Exception("Force rollback")
+            except Exception:
+                pass
+
+        await asyncio.gather(transaction1(), transaction2())
+        assert True not in dirty_read_occurred, "READ COMMITTED should prevent dirty reads"
+
+    @pytest.mark.asyncio
+    async def test_repeatable_read_consistency(self, async_mysql_backend, async_mysql_control_backend, async_isolation_test_table):
+        """Verify REPEATABLE READ provides consistent reads within a transaction (async).
+
+        REPEATABLE READ should ensure that if a row is read twice in the same
+        transaction, the same value is returned even if another transaction
+        committed a change.
+        """
+        read_values = []
+
+        async def transaction1():
+            """Transaction 1: Read the same row twice."""
+            try:
+                async_mysql_backend.transaction_manager.isolation_level = IsolationLevel.REPEATABLE_READ
+                async with async_mysql_backend.transaction():
+                    # First read
+                    rows1 = await async_mysql_backend.fetch_all(
+                        "select balance from async_isolation_test where name = %s",
+                        ("user1",)
+                    )
+                    read_values.append(rows1[0]["balance"])
+
+                    # Wait for transaction 2 to commit
+                    await asyncio.sleep(0.2)
+
+                    # Second read (should be same as first)
+                    rows2 = await async_mysql_backend.fetch_all(
+                        "select balance from async_isolation_test where name = %s",
+                        ("user1",)
+                    )
+                    read_values.append(rows2[0]["balance"])
+            except Exception as e:
+                read_values.append(str(e))
+
+        async def transaction2():
+            """Transaction 2: Modify and commit."""
+            try:
+                await asyncio.sleep(0.1)  # Wait for transaction 1's first read
+                async_mysql_control_backend.transaction_manager.isolation_level = IsolationLevel.READ_COMMITTED
+                async with async_mysql_control_backend.transaction():
+                    await async_mysql_control_backend.execute(
+                        "update async_isolation_test set balance = %s where name = %s",
+                        (Decimal("200.00"), "user1")
+                    )
+            except Exception as e:
+                pass
+
+        await asyncio.gather(transaction1(), transaction2())
+
+        # Both reads should return the same value
+        assert len(read_values) == 2, "Should have two reads"
+        assert read_values[0] == read_values[1], f"REPEATABLE READ should provide consistent reads: {read_values}"
+
+    @pytest.mark.asyncio
+    async def test_serializable_prevents_phantom_reads(self, async_mysql_backend, async_mysql_control_backend, async_isolation_test_table):
+        """Verify SERIALIZABLE prevents phantom reads (async).
+
+        Phantom reads occur when a transaction reads rows matching a condition,
+        then another transaction inserts a row matching that condition.
+        SERIALIZABLE should prevent this.
+        """
+        initial_count = []
+        second_count = []
+        insert_blocked = []
+
+        async def transaction1():
+            """Transaction 1: Count rows twice."""
+            try:
+                async_mysql_backend.transaction_manager.isolation_level = IsolationLevel.SERIALIZABLE
+                async with async_mysql_backend.transaction():
+                    # First count
+                    rows1 = await async_mysql_backend.fetch_all(
+                        "select count(*) as cnt from async_isolation_test where balance > %s",
+                        (Decimal("50.00"),)
+                    )
+                    initial_count.append(rows1[0]["cnt"])
+
+                    # Wait for transaction 2 to try insert
+                    await asyncio.sleep(0.2)
+
+                    # Second count (should be same)
+                    rows2 = await async_mysql_backend.fetch_all(
+                        "select count(*) as cnt from async_isolation_test where balance > %s",
+                        (Decimal("50.00"),)
+                    )
+                    second_count.append(rows2[0]["cnt"])
+            except Exception as e:
+                initial_count.append(str(e))
+
+        async def transaction2():
+            """Transaction 2: Try to insert a matching row."""
+            try:
+                await asyncio.sleep(0.1)  # Wait for transaction 1's first read
+                async_mysql_control_backend.transaction_manager.isolation_level = IsolationLevel.READ_COMMITTED
+                async with async_mysql_control_backend.transaction():
+                    # Try to insert a row that matches the condition
+                    await async_mysql_control_backend.execute(
+                        "insert into async_isolation_test (name, balance) values (%s, %s)",
+                        ("user2", Decimal("75.00"))
+                    )
+                insert_blocked.append(False)
+            except Exception as e:
+                # May be blocked by SERIALIZABLE lock
+                insert_blocked.append(True)
+
+        await asyncio.gather(transaction1(), transaction2())
+
+        # With SERIALIZABLE, the counts should be consistent
+        # (insert may be blocked or delayed until transaction 1 commits)
+        if len(initial_count) == 2 and isinstance(initial_count[0], int):
+            assert initial_count[0] == second_count[0], \
+                f"SERIALIZABLE should prevent phantom reads: {initial_count[0]} vs {second_count[0]}"
+
+
+class TestAsyncTransactionModeEffect:
+    """Test actual behavior of transaction modes."""
+
+    @pytest.mark.asyncio
+    async def test_read_only_mode_allows_reads(self, async_mysql_backend, async_mode_test_table):
+        """Verify READ ONLY mode allows read operations (async)."""
+        if not async_mysql_backend.dialect.supports_read_only_transaction():
+            pytest.skip("MySQL version does not support READ ONLY transactions")
+
+        async_mysql_backend.transaction_manager.transaction_mode = TransactionMode.READ_ONLY
+        async with async_mysql_backend.transaction():
+            rows = await async_mysql_backend.fetch_all("select * from async_mode_test")
+            assert len(rows) == 1
+            assert rows[0]["name"] == "account1"
+
+    @pytest.mark.asyncio
+    async def test_read_only_rejects_writes(self, async_mysql_backend, async_mode_test_table):
+        """Verify READ ONLY mode rejects write operations (async)."""
+        if not async_mysql_backend.dialect.supports_read_only_transaction():
+            pytest.skip("MySQL version does not support READ ONLY transactions")
+
+        async_mysql_backend.transaction_manager.transaction_mode = TransactionMode.READ_ONLY
+
+        with pytest.raises(Exception):
+            async with async_mysql_backend.transaction():
+                await async_mysql_backend.execute(
+                    "update async_mode_test set balance = %s where name = %s",
+                    (Decimal("500.00"), "account1")
+                )
+
+    @pytest.mark.asyncio
+    async def test_read_write_allows_writes(self, async_mysql_backend, async_mode_test_table):
+        """Verify READ WRITE mode allows write operations (async)."""
+        async_mysql_backend.transaction_manager.transaction_mode = TransactionMode.READ_WRITE
+
+        async with async_mysql_backend.transaction():
+            await async_mysql_backend.execute(
+                "update async_mode_test set balance = %s where name = %s",
+                (Decimal("500.00"), "account1")
+            )
+
+        rows = await async_mysql_backend.fetch_all(
+            "select balance from async_mode_test where name = %s",
+            ("account1",)
+        )
+        assert rows[0]["balance"] == Decimal("500.00")
+
+
+class TestAsyncTransactionCombination:
+    """Test isolation level combined with transaction mode."""
+
+    @pytest.mark.asyncio
+    async def test_serializable_with_read_only(self, async_mysql_backend, async_combo_test_table):
+        """Test SERIALIZABLE isolation with READ ONLY mode (async)."""
+        if not async_mysql_backend.dialect.supports_read_only_transaction():
+            pytest.skip("MySQL version does not support READ ONLY transactions")
+
+        async_mysql_backend.transaction_manager.isolation_level = IsolationLevel.SERIALIZABLE
+        async_mysql_backend.transaction_manager.transaction_mode = TransactionMode.READ_ONLY
+
+        async with async_mysql_backend.transaction():
+                rows = await async_mysql_backend.fetch_all("select * from async_combo_test")
+                assert len(rows) == 1
+
+    @pytest.mark.asyncio
+    async def test_repeatable_read_with_read_only(self, async_mysql_backend, async_combo_test_table):
+        """Test REPEATABLE READ isolation with READ ONLY mode (async)."""
+        if not async_mysql_backend.dialect.supports_read_only_transaction():
+            pytest.skip("MySQL version does not support READ ONLY transactions")
+
+        async_mysql_backend.transaction_manager.isolation_level = IsolationLevel.REPEATABLE_READ
+        async_mysql_backend.transaction_manager.transaction_mode = TransactionMode.READ_ONLY
+
+        async with async_mysql_backend.transaction():
+                rows = await async_mysql_backend.fetch_all("select * from async_combo_test")
+                assert len(rows) == 1
+
+    @pytest.mark.asyncio
+    async def test_default_isolation_is_repeatable_read(self, async_mysql_backend):
+        """Verify MySQL default isolation level is REPEATABLE READ (async)."""
+        async with async_mysql_backend.transaction():
+            rows = await async_mysql_backend.fetch_all(
+                "select @@transaction_isolation as isolation"
+            )
+            if rows and rows[0].get("isolation"):
+                isolation = rows[0]["isolation"]
+                assert "REPEATABLE READ" in isolation.upper() or "REPEATABLE-READ" in isolation.upper()
+
+    @pytest.mark.asyncio
+    async def test_isolation_level_cannot_change_during_transaction(self, async_mysql_backend, async_isolation_test_table):
+        """Verify isolation level cannot be changed during active transaction (async)."""
+        async with async_mysql_backend.transaction():
+            with pytest.raises(Exception):
+                async_mysql_backend.transaction_manager.isolation_level = IsolationLevel.SERIALIZABLE
+
+
+class TestAsyncNestedTransactionsWithIsolation:
+    """Test nested transactions (savepoints) with different isolation levels."""
+
+    @pytest.mark.asyncio
+    async def test_nested_transaction_with_isolation_level(self, async_mysql_backend, async_nested_test_table):
+        """Test that nested transactions work with isolation level set (async)."""
+        async_mysql_backend.transaction_manager.isolation_level = IsolationLevel.READ_COMMITTED
+
+        async with async_mysql_backend.transaction():
+            await async_mysql_backend.execute(
+                "insert into async_nested_test (name, value) values (%s, %s)",
+                ("outer", 1)
+            )
+
+            sp = await async_mysql_backend.transaction_manager.savepoint("sp1")
+
+            await async_mysql_backend.execute(
+                "insert into async_nested_test (name, value) values (%s, %s)",
+                ("inner", 2)
+            )
+
+            await async_mysql_backend.transaction_manager.rollback_to(sp)
+
+        rows = await async_mysql_backend.fetch_all("select * from async_nested_test order by id")
+        assert len(rows) == 1
+        assert rows[0]["name"] == "outer"

--- a/tests/rhosocial/activerecord_mysql_test/feature/backend/test_transaction_isolation_effect.py
+++ b/tests/rhosocial/activerecord_mysql_test/feature/backend/test_transaction_isolation_effect.py
@@ -104,19 +104,24 @@ class TestIsolationLevelEffects:
         # READ UNCOMMITTED should have detected the dirty read
         assert True in dirty_read_detected, "READ UNCOMMITTED should allow dirty reads"
 
-    def test_read_committed_prevents_dirty_reads(self, mysql_backend, test_table):
-        """Verify READ COMMITTED isolation level prevents dirty reads."""
+    def test_read_committed_prevents_dirty_reads(self, mysql_backend, mysql_control_backend, test_table):
+        """Verify READ COMMITTED isolation level prevents dirty reads.
+
+        Uses independent connections for each thread to avoid connection sharing issues.
+        """
+        backend1 = mysql_backend
+        backend2 = mysql_control_backend
         dirty_read_occurred = []
 
         def transaction1():
             """Transaction 1: Should not see uncommitted data."""
             try:
-                mysql_backend.transaction_manager.isolation_level = IsolationLevel.READ_COMMITTED
-                with mysql_backend.transaction():
+                backend1.transaction_manager.isolation_level = IsolationLevel.READ_COMMITTED
+                with backend1.transaction():
                     # Wait for transaction 2 to modify
                     time.sleep(0.15)
                     # Should NOT see the uncommitted change
-                    rows = mysql_backend.fetch_all(
+                    rows = backend1.fetch_all(
                         "SELECT balance FROM isolation_test WHERE name = %s",
                         ("user1",)
                     )
@@ -130,9 +135,9 @@ class TestIsolationLevelEffects:
         def transaction2():
             """Transaction 2: Modify and rollback."""
             try:
-                mysql_backend.transaction_manager.isolation_level = IsolationLevel.READ_COMMITTED
-                with mysql_backend.transaction():
-                    mysql_backend.execute(
+                backend2.transaction_manager.isolation_level = IsolationLevel.READ_COMMITTED
+                with backend2.transaction():
+                    backend2.execute(
                         "UPDATE isolation_test SET balance = %s WHERE name = %s",
                         (Decimal("200.00"), "user1")
                     )
@@ -152,22 +157,26 @@ class TestIsolationLevelEffects:
         # READ COMMITTED should NOT have dirty read
         assert False in dirty_read_occurred, "READ COMMITTED should prevent dirty reads"
 
-    def test_repeatable_read_consistency(self, mysql_backend, test_table):
+    def test_repeatable_read_consistency(self, mysql_backend, mysql_control_backend, test_table):
         """Verify REPEATABLE READ provides consistent reads within a transaction.
 
         REPEATABLE READ should ensure that if a row is read twice in the same
         transaction, the same value is returned even if another transaction
         committed a change.
+
+        Uses independent connections for each thread to avoid connection sharing issues.
         """
+        backend1 = mysql_backend
+        backend2 = mysql_control_backend
         read_values = []
 
         def transaction1():
             """Transaction 1: Read the same row twice."""
             try:
-                mysql_backend.transaction_manager.isolation_level = IsolationLevel.REPEATABLE_READ
-                with mysql_backend.transaction():
+                backend1.transaction_manager.isolation_level = IsolationLevel.REPEATABLE_READ
+                with backend1.transaction():
                     # First read
-                    rows1 = mysql_backend.fetch_all(
+                    rows1 = backend1.fetch_all(
                         "SELECT balance FROM isolation_test WHERE name = %s",
                         ("user1",)
                     )
@@ -177,7 +186,7 @@ class TestIsolationLevelEffects:
                     time.sleep(0.2)
 
                     # Second read (should be same as first)
-                    rows2 = mysql_backend.fetch_all(
+                    rows2 = backend1.fetch_all(
                         "SELECT balance FROM isolation_test WHERE name = %s",
                         ("user1",)
                     )
@@ -189,9 +198,9 @@ class TestIsolationLevelEffects:
             """Transaction 2: Modify and commit."""
             try:
                 time.sleep(0.1)  # Wait for transaction 1's first read
-                mysql_backend.transaction_manager.isolation_level = IsolationLevel.READ_COMMITTED
-                with mysql_backend.transaction():
-                    mysql_backend.execute(
+                backend2.transaction_manager.isolation_level = IsolationLevel.READ_COMMITTED
+                with backend2.transaction():
+                    backend2.execute(
                         "UPDATE isolation_test SET balance = %s WHERE name = %s",
                         (Decimal("200.00"), "user1")
                     )
@@ -210,13 +219,17 @@ class TestIsolationLevelEffects:
         assert len(read_values) == 2, "Should have two reads"
         assert read_values[0] == read_values[1], f"REPEATABLE READ should provide consistent reads: {read_values}"
 
-    def test_serializable_prevents_phantom_reads(self, mysql_backend, test_table):
+    def test_serializable_prevents_phantom_reads(self, mysql_backend, mysql_control_backend, test_table):
         """Verify SERIALIZABLE prevents phantom reads.
 
         Phantom reads occur when a transaction reads rows matching a condition,
         then another transaction inserts a row matching that condition.
         SERIALIZABLE should prevent this.
+
+        Uses independent connections for each thread to avoid connection sharing issues.
         """
+        backend1 = mysql_backend
+        backend2 = mysql_control_backend
         initial_count = []
         second_count = []
         insert_blocked = []
@@ -224,10 +237,10 @@ class TestIsolationLevelEffects:
         def transaction1():
             """Transaction 1: Count rows twice."""
             try:
-                mysql_backend.transaction_manager.isolation_level = IsolationLevel.SERIALIZABLE
-                with mysql_backend.transaction():
+                backend1.transaction_manager.isolation_level = IsolationLevel.SERIALIZABLE
+                with backend1.transaction():
                     # First count
-                    rows1 = mysql_backend.fetch_all(
+                    rows1 = backend1.fetch_all(
                         "SELECT COUNT(*) as cnt FROM isolation_test WHERE balance > %s",
                         (Decimal("50.00"),)
                     )
@@ -237,7 +250,7 @@ class TestIsolationLevelEffects:
                     time.sleep(0.2)
 
                     # Second count (should be same)
-                    rows2 = mysql_backend.fetch_all(
+                    rows2 = backend1.fetch_all(
                         "SELECT COUNT(*) as cnt FROM isolation_test WHERE balance > %s",
                         (Decimal("50.00"),)
                     )
@@ -249,10 +262,10 @@ class TestIsolationLevelEffects:
             """Transaction 2: Try to insert a matching row."""
             try:
                 time.sleep(0.1)  # Wait for transaction 1's first read
-                mysql_backend.transaction_manager.isolation_level = IsolationLevel.READ_COMMITTED
-                with mysql_backend.transaction():
+                backend2.transaction_manager.isolation_level = IsolationLevel.READ_COMMITTED
+                with backend2.transaction():
                     # Try to insert a row that matches the condition
-                    mysql_backend.execute(
+                    backend2.execute(
                         "INSERT INTO isolation_test (name, balance) VALUES (%s, %s)",
                         ("user2", Decimal("75.00"))
                     )

--- a/tests/rhosocial/activerecord_mysql_test/feature/backend/test_transaction_isolation_effect.py
+++ b/tests/rhosocial/activerecord_mysql_test/feature/backend/test_transaction_isolation_effect.py
@@ -431,6 +431,102 @@ class TestIsolationModeCombination:
                 isolation = rows[0]["isolation"]
                 assert "REPEATABLE READ" in isolation.upper() or "REPEATABLE-READ" in isolation.upper()
 
+    def test_no_isolation_level_set_uses_database_default(self, mysql_backend):
+        """Verify that when no isolation level is set, no SET TRANSACTION is sent.
+
+        This tests that:
+        1. The initial isolation_level is None (not REPEATABLE_READ)
+        2. No SET TRANSACTION statement is sent when user doesn't specify isolation
+        3. MySQL uses its default isolation level (REPEATABLE READ)
+        """
+        from unittest.mock import patch
+
+        # Verify initial state is None
+        assert mysql_backend.transaction_manager._isolation_level is None, \
+            "Initial isolation level should be None (use database default)"
+
+        # Track SQL statements executed
+        executed_statements = []
+        original_execute = mysql_backend.execute
+
+        def track_execute(sql, params=None, **kwargs):
+            executed_statements.append(sql)
+            return original_execute(sql, params, **kwargs)
+
+        # Patch execute to track statements
+        with patch.object(mysql_backend, 'execute', side_effect=track_execute):
+            with mysql_backend.transaction():
+                # Execute a simple query inside the transaction
+                mysql_backend.fetch_all("SELECT 1 as test")
+
+        # Verify no SET TRANSACTION was sent
+        set_transaction_found = any(
+            'SET TRANSACTION' in stmt.upper() for stmt in executed_statements
+        )
+        assert not set_transaction_found, \
+            f"SET TRANSACTION should NOT be sent when isolation level not specified. Executed: {executed_statements}"
+
+        # Verify START TRANSACTION was sent
+        start_transaction_found = any(
+            'START TRANSACTION' in stmt.upper() for stmt in executed_statements
+        )
+        assert start_transaction_found, \
+            f"START TRANSACTION should be sent. Executed: {executed_statements}"
+
+    def test_explicit_isolation_level_sends_set_transaction(self, mysql_backend):
+        """Verify that when isolation level is explicitly set, SET TRANSACTION is sent.
+
+        This tests that:
+        1. Setting isolation_level property changes the internal state
+        2. SET TRANSACTION statement is sent before START TRANSACTION
+        3. The correct isolation level is used
+        """
+        from unittest.mock import patch
+
+        # Set isolation level explicitly
+        mysql_backend.transaction_manager.isolation_level = IsolationLevel.READ_COMMITTED
+
+        # Verify internal state changed
+        assert mysql_backend.transaction_manager._isolation_level == IsolationLevel.READ_COMMITTED, \
+            "Isolation level should be READ_COMMITTED after explicit setting"
+
+        # Track SQL statements executed
+        executed_statements = []
+        original_execute = mysql_backend.execute
+
+        def track_execute(sql, params=None, **kwargs):
+            executed_statements.append(sql)
+            return original_execute(sql, params, **kwargs)
+
+        # Patch execute to track statements
+        with patch.object(mysql_backend, 'execute', side_effect=track_execute):
+            with mysql_backend.transaction():
+                mysql_backend.fetch_all("SELECT 1 as test")
+
+        # Verify SET TRANSACTION was sent with correct level
+        set_transaction_found = any(
+            'SET TRANSACTION' in stmt.upper() and 'READ COMMITTED' in stmt.upper()
+            for stmt in executed_statements
+        )
+        assert set_transaction_found, \
+            f"SET TRANSACTION READ COMMITTED should be sent. Executed: {executed_statements}"
+
+        # Verify SET TRANSACTION comes before START TRANSACTION
+        set_transaction_idx = next(
+            (i for i, stmt in enumerate(executed_statements)
+             if 'SET TRANSACTION' in stmt.upper()),
+            None
+        )
+        start_transaction_idx = next(
+            (i for i, stmt in enumerate(executed_statements)
+             if 'START TRANSACTION' in stmt.upper()),
+            None
+        )
+        assert set_transaction_idx is not None and start_transaction_idx is not None, \
+            "Both SET TRANSACTION and START TRANSACTION should be executed"
+        assert set_transaction_idx < start_transaction_idx, \
+            f"SET TRANSACTION should come before START TRANSACTION. Order: {executed_statements}"
+
     def test_isolation_level_cannot_change_during_transaction(self, mysql_backend, test_table):
         """Verify isolation level cannot be changed during active transaction."""
         with mysql_backend.transaction():

--- a/tests/rhosocial/activerecord_mysql_test/feature/backend/test_transaction_isolation_effect.py
+++ b/tests/rhosocial/activerecord_mysql_test/feature/backend/test_transaction_isolation_effect.py
@@ -405,11 +405,15 @@ class TestIsolationModeCombination:
     def test_default_isolation_is_repeatable_read(self, mysql_backend):
         """Verify MySQL default isolation level is REPEATABLE READ."""
         # Check the default isolation level
+        # MySQL 5.6 uses @@tx_isolation, MySQL 5.7+ uses @@transaction_isolation
+        # Detect version and use appropriate variable
+        version = mysql_backend.dialect.get_server_version()
+        isolation_var = "@@transaction_isolation" if version >= (5, 7, 0) else "@@tx_isolation"
+
         with mysql_backend.transaction():
             rows = mysql_backend.fetch_all(
-                "SELECT @@transaction_isolation as isolation"
+                f"SELECT {isolation_var} as isolation"
             )
-            # MySQL 8.0+ uses transaction_isolation
             if rows and rows[0].get("isolation"):
                 isolation = rows[0]["isolation"]
                 assert "REPEATABLE READ" in isolation.upper() or "REPEATABLE-READ" in isolation.upper()

--- a/tests/rhosocial/activerecord_mysql_test/feature/backend/test_transaction_isolation_effect.py
+++ b/tests/rhosocial/activerecord_mysql_test/feature/backend/test_transaction_isolation_effect.py
@@ -1,0 +1,467 @@
+# tests/rhosocial/activerecord_mysql_test/feature/backend/test_transaction_isolation_effect.py
+"""
+Tests for MySQL transaction isolation level actual effects.
+
+This module tests that different isolation levels actually provide
+the expected isolation behavior in MySQL backend.
+
+Tests cover:
+- READ UNCOMMITTED: Dirty reads allowed
+- READ COMMITTED: No dirty reads, but non-repeatable reads allowed
+- REPEATABLE READ: No dirty reads, no non-repeatable reads, but phantom reads possible
+- SERIALIZABLE: Full isolation, no phantom reads
+"""
+import pytest
+import threading
+import time
+from decimal import Decimal
+from typing import Type
+
+from rhosocial.activerecord.backend.impl.mysql import MySQLBackend
+from rhosocial.activerecord.backend.transaction import IsolationLevel
+from rhosocial.activerecord.backend.errors import TransactionError
+
+
+class TestIsolationLevelEffects:
+    """Test actual isolation behavior for each isolation level."""
+
+    @pytest.fixture
+    def test_table(self, mysql_backend):
+        """Create a test table for isolation tests."""
+        mysql_backend.execute("DROP TABLE IF EXISTS isolation_test")
+        mysql_backend.execute("""
+            CREATE TABLE isolation_test (
+                id INT AUTO_INCREMENT PRIMARY KEY,
+                name VARCHAR(255),
+                balance DECIMAL(10, 2),
+                version INT DEFAULT 1
+            )
+        """)
+        mysql_backend.execute(
+            "INSERT INTO isolation_test (name, balance) VALUES (%s, %s)",
+            ("user1", Decimal("100.00"))
+        )
+        yield "isolation_test"
+        mysql_backend.execute("DROP TABLE IF EXISTS isolation_test")
+
+    def test_read_uncommitted_allows_dirty_reads(self, mysql_backend, mysql_control_backend, test_table):
+        """Verify READ UNCOMMITTED isolation level allows dirty reads.
+
+        A dirty read occurs when a transaction reads data written by another
+        uncommitted transaction. READ UNCOMMITTED should allow this.
+
+        This test uses two separate backend connections to test isolation.
+        """
+        # Use control backend for transaction 2 (independent connection)
+        backend1 = mysql_backend
+        backend2 = mysql_control_backend
+
+        dirty_read_detected = []
+
+        def transaction1():
+            """Transaction 1: Read uncommitted data."""
+            try:
+                # Set isolation level before starting transaction
+                backend1.transaction_manager.isolation_level = IsolationLevel.READ_UNCOMMITTED
+                with backend1.transaction():
+                    # Wait for transaction 2 to modify
+                    time.sleep(0.15)
+                    # Read potentially uncommitted data
+                    rows = backend1.fetch_all(
+                        "SELECT balance FROM isolation_test WHERE name = %s",
+                        ("user1",)
+                    )
+                    if rows and rows[0]["balance"] == Decimal("200.00"):
+                        dirty_read_detected.append(True)
+            except Exception as e:
+                dirty_read_detected.append(str(e))
+
+        def transaction2():
+            """Transaction 2: Modify data without committing."""
+            try:
+                backend2.transaction_manager.isolation_level = IsolationLevel.READ_UNCOMMITTED
+                with backend2.transaction():
+                    # Update balance
+                    backend2.execute(
+                        "UPDATE isolation_test SET balance = %s WHERE name = %s",
+                        (Decimal("200.00"), "user1")
+                    )
+                    # Wait for transaction 1 to read
+                    time.sleep(0.3)
+                    # Rollback (dirty read scenario)
+                    raise Exception("Force rollback for dirty read test")
+            except Exception:
+                pass  # Expected rollback
+
+        t1 = threading.Thread(target=transaction1)
+        t2 = threading.Thread(target=transaction2)
+
+        t1.start()
+        t2.start()
+        t1.join(timeout=5)
+        t2.join(timeout=5)
+
+        # READ UNCOMMITTED should have detected the dirty read
+        assert True in dirty_read_detected, "READ UNCOMMITTED should allow dirty reads"
+
+    def test_read_committed_prevents_dirty_reads(self, mysql_backend, test_table):
+        """Verify READ COMMITTED isolation level prevents dirty reads."""
+        dirty_read_occurred = []
+
+        def transaction1():
+            """Transaction 1: Should not see uncommitted data."""
+            try:
+                mysql_backend.transaction_manager.isolation_level = IsolationLevel.READ_COMMITTED
+                with mysql_backend.transaction():
+                    # Wait for transaction 2 to modify
+                    time.sleep(0.15)
+                    # Should NOT see the uncommitted change
+                    rows = mysql_backend.fetch_all(
+                        "SELECT balance FROM isolation_test WHERE name = %s",
+                        ("user1",)
+                    )
+                    if rows and rows[0]["balance"] != Decimal("200.00"):
+                        dirty_read_occurred.append(False)  # Correct behavior
+                    else:
+                        dirty_read_occurred.append(True)  # Dirty read happened
+            except Exception as e:
+                dirty_read_occurred.append(str(e))
+
+        def transaction2():
+            """Transaction 2: Modify and rollback."""
+            try:
+                mysql_backend.transaction_manager.isolation_level = IsolationLevel.READ_COMMITTED
+                with mysql_backend.transaction():
+                    mysql_backend.execute(
+                        "UPDATE isolation_test SET balance = %s WHERE name = %s",
+                        (Decimal("200.00"), "user1")
+                    )
+                    time.sleep(0.2)
+                    raise Exception("Force rollback")
+            except Exception:
+                pass
+
+        t1 = threading.Thread(target=transaction1)
+        t2 = threading.Thread(target=transaction2)
+
+        t1.start()
+        t2.start()
+        t1.join(timeout=5)
+        t2.join(timeout=5)
+
+        # READ COMMITTED should NOT have dirty read
+        assert False in dirty_read_occurred, "READ COMMITTED should prevent dirty reads"
+
+    def test_repeatable_read_consistency(self, mysql_backend, test_table):
+        """Verify REPEATABLE READ provides consistent reads within a transaction.
+
+        REPEATABLE READ should ensure that if a row is read twice in the same
+        transaction, the same value is returned even if another transaction
+        committed a change.
+        """
+        read_values = []
+
+        def transaction1():
+            """Transaction 1: Read the same row twice."""
+            try:
+                mysql_backend.transaction_manager.isolation_level = IsolationLevel.REPEATABLE_READ
+                with mysql_backend.transaction():
+                    # First read
+                    rows1 = mysql_backend.fetch_all(
+                        "SELECT balance FROM isolation_test WHERE name = %s",
+                        ("user1",)
+                    )
+                    read_values.append(rows1[0]["balance"])
+
+                    # Wait for transaction 2 to commit
+                    time.sleep(0.2)
+
+                    # Second read (should be same as first)
+                    rows2 = mysql_backend.fetch_all(
+                        "SELECT balance FROM isolation_test WHERE name = %s",
+                        ("user1",)
+                    )
+                    read_values.append(rows2[0]["balance"])
+            except Exception as e:
+                read_values.append(str(e))
+
+        def transaction2():
+            """Transaction 2: Modify and commit."""
+            try:
+                time.sleep(0.1)  # Wait for transaction 1's first read
+                mysql_backend.transaction_manager.isolation_level = IsolationLevel.READ_COMMITTED
+                with mysql_backend.transaction():
+                    mysql_backend.execute(
+                        "UPDATE isolation_test SET balance = %s WHERE name = %s",
+                        (Decimal("200.00"), "user1")
+                    )
+            except Exception as e:
+                pass
+
+        t1 = threading.Thread(target=transaction1)
+        t2 = threading.Thread(target=transaction2)
+
+        t1.start()
+        t2.start()
+        t1.join(timeout=5)
+        t2.join(timeout=5)
+
+        # Both reads should return the same value
+        assert len(read_values) == 2, "Should have two reads"
+        assert read_values[0] == read_values[1], f"REPEATABLE READ should provide consistent reads: {read_values}"
+
+    def test_serializable_prevents_phantom_reads(self, mysql_backend, test_table):
+        """Verify SERIALIZABLE prevents phantom reads.
+
+        Phantom reads occur when a transaction reads rows matching a condition,
+        then another transaction inserts a row matching that condition.
+        SERIALIZABLE should prevent this.
+        """
+        initial_count = []
+        second_count = []
+        insert_blocked = []
+
+        def transaction1():
+            """Transaction 1: Count rows twice."""
+            try:
+                mysql_backend.transaction_manager.isolation_level = IsolationLevel.SERIALIZABLE
+                with mysql_backend.transaction():
+                    # First count
+                    rows1 = mysql_backend.fetch_all(
+                        "SELECT COUNT(*) as cnt FROM isolation_test WHERE balance > %s",
+                        (Decimal("50.00"),)
+                    )
+                    initial_count.append(rows1[0]["cnt"])
+
+                    # Wait for transaction 2 to try insert
+                    time.sleep(0.2)
+
+                    # Second count (should be same)
+                    rows2 = mysql_backend.fetch_all(
+                        "SELECT COUNT(*) as cnt FROM isolation_test WHERE balance > %s",
+                        (Decimal("50.00"),)
+                    )
+                    second_count.append(rows2[0]["cnt"])
+            except Exception as e:
+                initial_count.append(str(e))
+
+        def transaction2():
+            """Transaction 2: Try to insert a matching row."""
+            try:
+                time.sleep(0.1)  # Wait for transaction 1's first read
+                mysql_backend.transaction_manager.isolation_level = IsolationLevel.READ_COMMITTED
+                with mysql_backend.transaction():
+                    # Try to insert a row that matches the condition
+                    mysql_backend.execute(
+                        "INSERT INTO isolation_test (name, balance) VALUES (%s, %s)",
+                        ("user2", Decimal("75.00"))
+                    )
+                insert_blocked.append(False)
+            except Exception as e:
+                # May be blocked by SERIALIZABLE lock
+                insert_blocked.append(True)
+
+        t1 = threading.Thread(target=transaction1)
+        t2 = threading.Thread(target=transaction2)
+
+        t1.start()
+        t2.start()
+        t1.join(timeout=5)
+        t2.join(timeout=5)
+
+        # With SERIALIZABLE, the counts should be consistent
+        # (insert may be blocked or delayed until transaction 1 commits)
+        if len(initial_count) == 2 and isinstance(initial_count[0], int):
+            assert initial_count[0] == second_count[0], \
+                f"SERIALIZABLE should prevent phantom reads: {initial_count[0]} vs {second_count[0]}"
+
+
+class TestTransactionModeEffects:
+    """Test actual effects of READ ONLY and READ WRITE transaction modes."""
+
+    @pytest.fixture
+    def test_table(self, mysql_backend):
+        """Create a test table for transaction mode tests."""
+        mysql_backend.execute("DROP TABLE IF EXISTS mode_test")
+        mysql_backend.execute("""
+            CREATE TABLE mode_test (
+                id INT AUTO_INCREMENT PRIMARY KEY,
+                name VARCHAR(255),
+                value INT
+            )
+        """)
+        mysql_backend.execute(
+            "INSERT INTO mode_test (name, value) VALUES (%s, %s)",
+            ("item1", 100)
+        )
+        yield "mode_test"
+        mysql_backend.execute("DROP TABLE IF EXISTS mode_test")
+
+    def test_read_only_mode_rejects_writes(self, mysql_backend, test_table):
+        """Verify READ ONLY mode rejects write operations.
+
+        MySQL 5.6.5+ supports READ ONLY transactions. Any attempt to modify
+        data in a READ ONLY transaction should fail.
+        """
+        # Check if READ ONLY is supported
+        if not mysql_backend.dialect.supports_read_only_transaction():
+            pytest.skip("MySQL version does not support READ ONLY transactions")
+
+        error_caught = False
+        try:
+            from rhosocial.activerecord.backend.transaction import TransactionMode
+            mysql_backend.transaction_manager.transaction_mode = TransactionMode.READ_ONLY
+            with mysql_backend.transaction():
+                # Attempt to insert (should fail)
+                mysql_backend.execute(
+                    "INSERT INTO mode_test (name, value) VALUES (%s, %s)",
+                    ("item2", 200)
+                )
+        except Exception as e:
+            error_caught = True
+            # Verify it's the right error
+            assert "read-only" in str(e).lower() or "cannot execute" in str(e).lower() or "1792" in str(e)
+
+        assert error_caught, "READ ONLY transaction should reject write operations"
+
+    def test_read_only_mode_allows_reads(self, mysql_backend, test_table):
+        """Verify READ ONLY mode allows read operations."""
+        if not mysql_backend.dialect.supports_read_only_transaction():
+            pytest.skip("MySQL version does not support READ ONLY transactions")
+
+        from rhosocial.activerecord.backend.transaction import TransactionMode
+        mysql_backend.transaction_manager.transaction_mode = TransactionMode.READ_ONLY
+        with mysql_backend.transaction():
+            rows = mysql_backend.fetch_all("SELECT * FROM mode_test")
+            assert len(rows) == 1
+            assert rows[0]["name"] == "item1"
+
+    def test_read_write_mode_allows_writes(self, mysql_backend, test_table):
+        """Verify READ WRITE mode allows write operations."""
+        from rhosocial.activerecord.backend.transaction import TransactionMode
+        mysql_backend.transaction_manager.transaction_mode = TransactionMode.READ_WRITE
+        with mysql_backend.transaction():
+            mysql_backend.execute(
+                "INSERT INTO mode_test (name, value) VALUES (%s, %s)",
+                ("item2", 200)
+            )
+
+        rows = mysql_backend.fetch_all("SELECT * FROM mode_test ORDER BY id")
+        assert len(rows) == 2
+        assert rows[1]["name"] == "item2"
+
+
+class TestIsolationModeCombination:
+    """Test combinations of isolation levels and transaction modes."""
+
+    @pytest.fixture
+    def test_table(self, mysql_backend):
+        """Create a test table for combination tests."""
+        mysql_backend.execute("DROP TABLE IF EXISTS combo_test")
+        mysql_backend.execute("""
+            CREATE TABLE combo_test (
+                id INT AUTO_INCREMENT PRIMARY KEY,
+                name VARCHAR(255),
+                balance DECIMAL(10, 2)
+            )
+        """)
+        mysql_backend.execute(
+            "INSERT INTO combo_test (name, balance) VALUES (%s, %s)",
+            ("account1", Decimal("1000.00"))
+        )
+        yield "combo_test"
+        mysql_backend.execute("DROP TABLE IF EXISTS combo_test")
+
+    def test_serializable_with_read_only(self, mysql_backend, test_table):
+        """Test SERIALIZABLE isolation with READ ONLY mode."""
+        if not mysql_backend.dialect.supports_read_only_transaction():
+            pytest.skip("MySQL version does not support READ ONLY transactions")
+
+        from rhosocial.activerecord.backend.transaction import TransactionMode
+
+        # Set both isolation level and mode
+        mysql_backend.transaction_manager.isolation_level = IsolationLevel.SERIALIZABLE
+        mysql_backend.transaction_manager.transaction_mode = TransactionMode.READ_ONLY
+
+        with mysql_backend.transaction():
+            # Should be able to read
+            rows = mysql_backend.fetch_all("SELECT * FROM combo_test")
+            assert len(rows) == 1
+
+    def test_repeatable_read_with_read_only(self, mysql_backend, test_table):
+        """Test REPEATABLE READ isolation with READ ONLY mode."""
+        if not mysql_backend.dialect.supports_read_only_transaction():
+            pytest.skip("MySQL version does not support READ ONLY transactions")
+
+        from rhosocial.activerecord.backend.transaction import TransactionMode
+
+        mysql_backend.transaction_manager.isolation_level = IsolationLevel.REPEATABLE_READ
+        mysql_backend.transaction_manager.transaction_mode = TransactionMode.READ_ONLY
+
+        with mysql_backend.transaction():
+            rows = mysql_backend.fetch_all("SELECT * FROM combo_test")
+            assert len(rows) == 1
+
+    def test_default_isolation_is_repeatable_read(self, mysql_backend):
+        """Verify MySQL default isolation level is REPEATABLE READ."""
+        # Check the default isolation level
+        with mysql_backend.transaction():
+            rows = mysql_backend.fetch_all(
+                "SELECT @@transaction_isolation as isolation"
+            )
+            # MySQL 8.0+ uses transaction_isolation
+            if rows and rows[0].get("isolation"):
+                isolation = rows[0]["isolation"]
+                assert "REPEATABLE READ" in isolation.upper() or "REPEATABLE-READ" in isolation.upper()
+
+    def test_isolation_level_cannot_change_during_transaction(self, mysql_backend, test_table):
+        """Verify isolation level cannot be changed during active transaction."""
+        with mysql_backend.transaction():
+            with pytest.raises(Exception):  # IsolationLevelError
+                mysql_backend.transaction_manager.isolation_level = IsolationLevel.SERIALIZABLE
+
+
+class TestNestedTransactionsWithIsolation:
+    """Test nested transactions (savepoints) with different isolation levels."""
+
+    @pytest.fixture
+    def test_table(self, mysql_backend):
+        """Create a test table for nested transaction tests."""
+        mysql_backend.execute("DROP TABLE IF EXISTS nested_test")
+        mysql_backend.execute("""
+            CREATE TABLE nested_test (
+                id INT AUTO_INCREMENT PRIMARY KEY,
+                name VARCHAR(255),
+                value INT
+            )
+        """)
+        yield "nested_test"
+        mysql_backend.execute("DROP TABLE IF EXISTS nested_test")
+
+    def test_nested_transaction_with_isolation_level(self, mysql_backend, test_table):
+        """Test that nested transactions work with isolation level set."""
+        mysql_backend.transaction_manager.isolation_level = IsolationLevel.READ_COMMITTED
+
+        with mysql_backend.transaction():
+            # Insert first record
+            mysql_backend.execute(
+                "INSERT INTO nested_test (name, value) VALUES (%s, %s)",
+                ("outer", 1)
+            )
+
+            # Create savepoint
+            sp = mysql_backend.transaction_manager.savepoint("sp1")
+
+            # Insert second record
+            mysql_backend.execute(
+                "INSERT INTO nested_test (name, value) VALUES (%s, %s)",
+                ("inner", 2)
+            )
+
+            # Rollback to savepoint
+            mysql_backend.transaction_manager.rollback_to(sp)
+
+        # Only outer record should exist
+        rows = mysql_backend.fetch_all("SELECT * FROM nested_test ORDER BY id")
+        assert len(rows) == 1
+        assert rows[0]["name"] == "outer"

--- a/tests/rhosocial/activerecord_test/feature/backend/mysql/conftest.py
+++ b/tests/rhosocial/activerecord_test/feature/backend/mysql/conftest.py
@@ -1,0 +1,11 @@
+# tests/rhosocial/activerecord_test/feature/backend/mysql/conftest.py
+"""Fixtures for MySQL transaction expression tests."""
+import pytest
+
+from rhosocial.activerecord.backend.impl.mysql.dialect import MySQLDialect
+
+
+@pytest.fixture(scope="function")
+def mysql_dialect():
+    """Fixture providing MySQLDialect instance for testing transaction expressions."""
+    return MySQLDialect()

--- a/tests/rhosocial/activerecord_test/feature/backend/mysql/test_expressions_transaction.py
+++ b/tests/rhosocial/activerecord_test/feature/backend/mysql/test_expressions_transaction.py
@@ -1,0 +1,142 @@
+# tests/rhosocial/activerecord_test/feature/backend/mysql/test_expressions_transaction.py
+"""Tests for MySQL transaction expression classes."""
+import pytest
+from rhosocial.activerecord.backend.expression.transaction import (
+    BeginTransactionExpression,
+    CommitTransactionExpression,
+    RollbackTransactionExpression,
+    SavepointExpression,
+    ReleaseSavepointExpression,
+    SetTransactionExpression,
+)
+from rhosocial.activerecord.backend.transaction import IsolationLevel, TransactionMode
+
+
+class TestMySQLBeginTransactionExpression:
+    """Tests for MySQL BeginTransactionExpression."""
+
+    def test_basic_begin(self, mysql_dialect):
+        """Test basic START TRANSACTION."""
+        expr = BeginTransactionExpression(mysql_dialect)
+        sql, params = expr.to_sql()
+        assert sql == "START TRANSACTION"
+        assert params == ()
+
+    def test_begin_with_isolation_level(self, mysql_dialect):
+        """Test START TRANSACTION with isolation level (requires SET TRANSACTION first)."""
+        expr = BeginTransactionExpression(mysql_dialect)
+        expr.isolation_level(IsolationLevel.SERIALIZABLE)
+        sql, params = expr.to_sql()
+        assert "SET TRANSACTION ISOLATION LEVEL SERIALIZABLE" in sql
+        assert "START TRANSACTION" in sql
+        assert params == ()
+
+    def test_begin_read_only(self, mysql_dialect):
+        """Test START TRANSACTION READ ONLY."""
+        expr = BeginTransactionExpression(mysql_dialect)
+        expr.read_only()
+        sql, params = expr.to_sql()
+        assert sql == "START TRANSACTION READ ONLY"
+        assert params == ()
+
+    def test_begin_read_write(self, mysql_dialect):
+        """Test START TRANSACTION READ WRITE."""
+        expr = BeginTransactionExpression(mysql_dialect)
+        expr.read_write()
+        sql, params = expr.to_sql()
+        assert sql == "START TRANSACTION"
+        assert params == ()
+
+    def test_begin_with_isolation_and_read_only(self, mysql_dialect):
+        """Test START TRANSACTION with isolation level and READ ONLY."""
+        expr = BeginTransactionExpression(mysql_dialect)
+        expr.isolation_level(IsolationLevel.READ_COMMITTED).read_only()
+        sql, params = expr.to_sql()
+        assert "SET TRANSACTION ISOLATION LEVEL READ COMMITTED" in sql
+        assert "START TRANSACTION READ ONLY" in sql
+        assert params == ()
+
+    @pytest.mark.parametrize("level,expected_name", [
+        (IsolationLevel.READ_UNCOMMITTED, "READ UNCOMMITTED"),
+        (IsolationLevel.READ_COMMITTED, "READ COMMITTED"),
+        (IsolationLevel.REPEATABLE_READ, "REPEATABLE READ"),
+        (IsolationLevel.SERIALIZABLE, "SERIALIZABLE"),
+    ])
+    def test_all_isolation_levels(self, mysql_dialect, level, expected_name):
+        """Test all isolation levels."""
+        expr = BeginTransactionExpression(mysql_dialect)
+        expr.isolation_level(level)
+        sql, params = expr.to_sql()
+        assert expected_name in sql
+        assert params == ()
+
+
+class TestMySQLCommitRollback:
+    """Tests for MySQL COMMIT and ROLLBACK."""
+
+    def test_commit(self, mysql_dialect):
+        """Test COMMIT statement."""
+        expr = CommitTransactionExpression(mysql_dialect)
+        sql, params = expr.to_sql()
+        assert sql == "COMMIT"
+        assert params == ()
+
+    def test_rollback(self, mysql_dialect):
+        """Test ROLLBACK statement."""
+        expr = RollbackTransactionExpression(mysql_dialect)
+        sql, params = expr.to_sql()
+        assert sql == "ROLLBACK"
+        assert params == ()
+
+    def test_rollback_to_savepoint(self, mysql_dialect):
+        """Test ROLLBACK TO SAVEPOINT statement."""
+        expr = RollbackTransactionExpression(mysql_dialect)
+        expr.to_savepoint("my_savepoint")
+        sql, params = expr.to_sql()
+        assert "ROLLBACK" in sql
+        assert "SAVEPOINT" in sql
+        assert params == ()
+
+
+class TestMySQLSavepoint:
+    """Tests for MySQL SAVEPOINT operations."""
+
+    def test_savepoint(self, mysql_dialect):
+        """Test SAVEPOINT statement."""
+        expr = SavepointExpression(mysql_dialect, "my_savepoint")
+        sql, params = expr.to_sql()
+        assert "SAVEPOINT" in sql
+        assert "my_savepoint" in sql
+        assert params == ()
+
+    def test_release_savepoint(self, mysql_dialect):
+        """Test RELEASE SAVEPOINT statement."""
+        expr = ReleaseSavepointExpression(mysql_dialect, "my_savepoint")
+        sql, params = expr.to_sql()
+        assert "RELEASE SAVEPOINT" in sql
+        assert "my_savepoint" in sql
+        assert params == ()
+
+
+class TestMySQLTransactionCapabilities:
+    """Tests for MySQL transaction capabilities."""
+
+    def test_supports_transaction_mode(self, mysql_dialect):
+        """Test MySQL supports transaction mode."""
+        assert mysql_dialect.supports_transaction_mode() == True
+
+    def test_supports_isolation_level_in_begin(self, mysql_dialect):
+        """Test MySQL does not support isolation level in BEGIN."""
+        assert mysql_dialect.supports_isolation_level_in_begin() == False
+
+    def test_supports_read_only_transaction(self, mysql_dialect):
+        """Test MySQL supports READ ONLY transactions (5.6.5+)."""
+        assert mysql_dialect.supports_read_only_transaction() == True
+
+    def test_supports_deferrable_transaction(self, mysql_dialect):
+        """Test MySQL does not support DEFERRABLE transactions."""
+        assert mysql_dialect.supports_deferrable_transaction() == False
+
+    def test_supports_savepoint(self, mysql_dialect):
+        """Test MySQL supports savepoints."""
+        assert mysql_dialect.supports_savepoint() == True

--- a/tests/rhosocial/activerecord_test/feature/backend/mysql/test_expressions_transaction.py
+++ b/tests/rhosocial/activerecord_test/feature/backend/mysql/test_expressions_transaction.py
@@ -1,5 +1,12 @@
 # tests/rhosocial/activerecord_test/feature/backend/mysql/test_expressions_transaction.py
-"""Tests for MySQL transaction expression classes."""
+"""Tests for MySQL transaction expression classes.
+
+MySQL Transaction Behavior:
+- Isolation level must be set BEFORE START TRANSACTION using SET TRANSACTION
+- START TRANSACTION can include READ ONLY / READ WRITE modes
+- The dialect's format_begin_transaction() only returns START TRANSACTION
+- SetTransactionExpression is used for isolation level settings
+"""
 import pytest
 from rhosocial.activerecord.backend.expression.transaction import (
     BeginTransactionExpression,
@@ -13,7 +20,12 @@ from rhosocial.activerecord.backend.transaction import IsolationLevel, Transacti
 
 
 class TestMySQLBeginTransactionExpression:
-    """Tests for MySQL BeginTransactionExpression."""
+    """Tests for MySQL BeginTransactionExpression.
+
+    Note: MySQL does not support isolation level in START TRANSACTION.
+    The dialect's supports_isolation_level_in_begin() returns False.
+    Use SetTransactionExpression to set isolation level before START TRANSACTION.
+    """
 
     def test_basic_begin(self, mysql_dialect):
         """Test basic START TRANSACTION."""
@@ -22,14 +34,21 @@ class TestMySQLBeginTransactionExpression:
         assert sql == "START TRANSACTION"
         assert params == ()
 
-    def test_begin_with_isolation_level(self, mysql_dialect):
-        """Test START TRANSACTION with isolation level (requires SET TRANSACTION first)."""
+    def test_begin_with_isolation_level_returns_only_start(self, mysql_dialect):
+        """Test that isolation level is NOT included in START TRANSACTION.
+
+        MySQL requires SET TRANSACTION ISOLATION LEVEL to be executed
+        separately before START TRANSACTION. The dialect's format_begin_transaction()
+        only returns the START TRANSACTION statement.
+        """
         expr = BeginTransactionExpression(mysql_dialect)
         expr.isolation_level(IsolationLevel.SERIALIZABLE)
         sql, params = expr.to_sql()
-        assert "SET TRANSACTION ISOLATION LEVEL SERIALIZABLE" in sql
-        assert "START TRANSACTION" in sql
+        # MySQL dialect does NOT include isolation level in START TRANSACTION
+        assert sql == "START TRANSACTION"
         assert params == ()
+        # Verify dialect capability
+        assert mysql_dialect.supports_isolation_level_in_begin() == False
 
     def test_begin_read_only(self, mysql_dialect):
         """Test START TRANSACTION READ ONLY."""
@@ -48,12 +67,51 @@ class TestMySQLBeginTransactionExpression:
         assert params == ()
 
     def test_begin_with_isolation_and_read_only(self, mysql_dialect):
-        """Test START TRANSACTION with isolation level and READ ONLY."""
+        """Test START TRANSACTION with isolation level and READ ONLY.
+
+        The isolation level is ignored by the dialect in START TRANSACTION.
+        Use SetTransactionExpression for isolation level, then BeginTransactionExpression
+        for READ ONLY mode.
+        """
         expr = BeginTransactionExpression(mysql_dialect)
         expr.isolation_level(IsolationLevel.READ_COMMITTED).read_only()
         sql, params = expr.to_sql()
-        assert "SET TRANSACTION ISOLATION LEVEL READ COMMITTED" in sql
-        assert "START TRANSACTION READ ONLY" in sql
+        # Only READ ONLY mode is included, isolation level is NOT
+        assert sql == "START TRANSACTION READ ONLY"
+        assert params == ()
+
+    @pytest.mark.parametrize("level", [
+        IsolationLevel.READ_UNCOMMITTED,
+        IsolationLevel.READ_COMMITTED,
+        IsolationLevel.REPEATABLE_READ,
+        IsolationLevel.SERIALIZABLE,
+    ])
+    def test_begin_with_isolation_returns_start_transaction(self, mysql_dialect, level):
+        """Test that START TRANSACTION does not include isolation level.
+
+        MySQL requires separate SET TRANSACTION ISOLATION LEVEL statement.
+        """
+        expr = BeginTransactionExpression(mysql_dialect)
+        expr.isolation_level(level)
+        sql, params = expr.to_sql()
+        # MySQL dialect does NOT include isolation level
+        assert sql == "START TRANSACTION"
+        assert params == ()
+
+
+class TestMySQLSetTransactionExpression:
+    """Tests for MySQL SetTransactionExpression.
+
+    MySQL uses SET TRANSACTION ISOLATION LEVEL before START TRANSACTION
+    to set the isolation level for the next transaction.
+    """
+
+    def test_set_isolation_level(self, mysql_dialect):
+        """Test SET TRANSACTION ISOLATION LEVEL."""
+        expr = SetTransactionExpression(mysql_dialect)
+        expr.isolation_level(IsolationLevel.SERIALIZABLE)
+        sql, params = expr.to_sql()
+        assert sql == "SET TRANSACTION ISOLATION LEVEL SERIALIZABLE"
         assert params == ()
 
     @pytest.mark.parametrize("level,expected_name", [
@@ -63,11 +121,27 @@ class TestMySQLBeginTransactionExpression:
         (IsolationLevel.SERIALIZABLE, "SERIALIZABLE"),
     ])
     def test_all_isolation_levels(self, mysql_dialect, level, expected_name):
-        """Test all isolation levels."""
-        expr = BeginTransactionExpression(mysql_dialect)
+        """Test all isolation levels in SET TRANSACTION."""
+        expr = SetTransactionExpression(mysql_dialect)
         expr.isolation_level(level)
         sql, params = expr.to_sql()
         assert expected_name in sql
+        assert params == ()
+
+    def test_set_read_only(self, mysql_dialect):
+        """Test SET TRANSACTION READ ONLY."""
+        expr = SetTransactionExpression(mysql_dialect)
+        expr.read_only()
+        sql, params = expr.to_sql()
+        assert sql == "SET TRANSACTION READ ONLY"
+        assert params == ()
+
+    def test_set_read_write(self, mysql_dialect):
+        """Test SET TRANSACTION READ WRITE."""
+        expr = SetTransactionExpression(mysql_dialect)
+        expr.read_write()
+        sql, params = expr.to_sql()
+        assert sql == "SET TRANSACTION READ WRITE"
         assert params == ()
 
 


### PR DESCRIPTION
## Description

This PR adds comprehensive transaction control support for the MySQL backend, including:

1. **TransactionControlSupport Protocol Implementation**: Adds the `TransactionControlSupport` protocol to `MySQLDialect`, enabling transaction isolation level and access mode (READ ONLY/READ WRITE) control.

2. **Refactored Transaction Management**: Moves isolation level handling directly into `MySQLTransactionManager` and `AsyncMySQLTransactionManager`, ensuring proper execution order of `SET TRANSACTION ISOLATION LEVEL` before `START TRANSACTION`.

3. **Comprehensive Test Coverage**: Adds 24 new tests (12 sync + 12 async) for transaction isolation level effects, covering dirty reads, repeatable reads, phantom reads, and transaction modes.

### Key Changes

- `dialect.py`: Add `format_begin_transaction()` with isolation level and READ ONLY support
- `transaction.py` / `async_transaction.py`: Refactor to use backend.execute() and handle isolation levels internally
- New test files: `test_transaction_isolation_effect.py`, `test_async_transaction_isolation_effect.py`
- New test file: `test_expressions_transaction.py` for transaction expression support

## Type of change

- [x] `feat`: A new feature
- [x] `test`: Adding missing tests or correcting existing tests (for the new feature)
- [ ] `docs`: Documentation only changes (if related to the new feature)
- [ ] `perf`: A code change that improves performance (if part of the feature)
- [ ] `chore`: Changes to the build process or auxiliary tools and libraries suchs as documentation generation (if related to the new feature)
- [ ] `ci`: Changes to our CI configuration files and scripts (if related to the new feature)
- [ ] `build`: Changes that affect the build system or external dependencies (if related to the new feature)
- [ ] `revert`: Reverts a previous commit

## Breaking Change

- [ ] Yes
- [x] No

**Applicable `rhosocial-activerecord` Version Range:**
>=1.0.0.dev12

## Related Repositories/Packages

This change is specific to `python-activerecord-mysql`. The core `python-activerecord` package already defines the `TransactionControlSupport` protocol that this implementation follows.

## Testing

- [x] I have added new tests to cover my changes.
- [ ] I have updated existing tests to reflect my changes.
- [x] All existing tests pass.
- [x] This change has been tested on MySQL 8.0+.

**Test Plan:**
- `pytest tests/rhosocial/activerecord_test/feature/backend/mysql/test_expressions_transaction.py`
- `pytest tests/rhosocial/activerecord_test/feature/backend/mysql/test_transaction_isolation_effect.py`
- `pytest tests/rhosocial/activerecord_test/feature/backend/mysql/test_async_transaction_isolation_effect.py`

## Checklist

- [x] My code follows the project's [code style guidelines](./.gemini/code_style.md).
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation (Docstrings, `README.md`, etc.).
- [x] My changes generate no new warnings.
- [ ] I have added a [Changelog fragment](./.gemini/version_control.md#5-changelog-management-with-towncrier) (`changelog.d/<issue_number>.<type>.md`).
- [x] I have verified that my changes do not introduce SQL injection vulnerabilities.
- [x] I have checked for potential performance regressions.

## Commits in this PR

1. `feat(backend): add TransactionControlSupport protocol for MySQL dialect`
   - Implement TransactionControlSupport protocol in MySQLDialect
   - Add format_begin_transaction() with isolation level and READ ONLY support

2. `refactor(backend): move isolation level handling to MySQLTransactionManager`
   - Add isolation_level property with getter/setter in transaction managers
   - Override _do_begin() to execute SET TRANSACTION before START TRANSACTION

3. `test(backend): add transaction isolation level effect tests for MySQL`
   - Test dirty reads, repeatable reads, phantom reads
   - Test READ ONLY and READ WRITE transaction modes

## Additional Notes

This implementation ensures MySQL-specific transaction control behavior is properly handled, with the isolation level being set before each transaction begins using separate SQL statements as required by MySQL.
