### PR TITLE
feat(mysql): add math enhanced functions with proper naming

### DIFF
--- a/changelog.d/29.added.md
+++ b/changelog.d/29.added.md
@@ -1,0 +1,1 @@
+Added MySQL math enhanced functions including round_, pow, power, sqrt, mod, ceil, floor, trunc, max_, min_, and avg with proper Python-safe naming.

--- a/src/rhosocial/activerecord/backend/impl/mysql/functions/__init__.py
+++ b/src/rhosocial/activerecord/backend/impl/mysql/functions/__init__.py
@@ -9,16 +9,19 @@ objects, organized into submodules by category:
 - spatial: Spatial/geometric functions (st_geom_from_text, st_distance, etc.)
 - fulltext: Full-text search functions (match_against)
 - enum_set: SET and Enum type functions (find_in_set, elt, field)
+- math_enhanced: Enhanced math functions (round, pow, sqrt, ceil, floor, etc.)
 
 Usage:
     from rhosocial.activerecord.backend.impl.mysql.functions import json_extract
     from rhosocial.activerecord.backend.impl.mysql.functions import st_distance
     from rhosocial.activerecord.backend.impl.mysql.functions import match_against
+    from rhosocial.activerecord.backend.impl.mysql.functions import round_
 
 Or import directly from submodules:
     from rhosocial.activerecord.backend.impl.mysql.functions.json import json_extract
     from rhosocial.activerecord.backend.impl.mysql.functions.spatial import st_distance
     from rhosocial.activerecord.backend.impl.mysql.functions.fulltext import match_against
+    from rhosocial.activerecord.backend.impl.mysql.functions.math_enhanced import round_
 
 Version Requirements:
 - JSON functions: MySQL 5.7.8+
@@ -26,6 +29,7 @@ Version Requirements:
 - GeoJSON functions: MySQL 5.7.5+
 - Full-text search: MySQL 5.6+ (with some features requiring 5.7+)
 - SET type: All MySQL versions
+- Math functions: All MySQL versions
 """
 
 from .json import (
@@ -39,6 +43,20 @@ from .json import (
     json_type,
     json_valid,
     json_search,
+)
+
+from .math_enhanced import (
+    round_,
+    pow,
+    power,
+    sqrt,
+    mod,
+    ceil,
+    floor,
+    trunc,
+    max_,
+    min_,
+    avg,
 )
 
 from .spatial import (
@@ -90,4 +108,16 @@ __all__ = [
     # Enum type functions
     "elt",
     "field",
+    # Math enhanced functions
+    "round_",
+    "pow",
+    "power",
+    "sqrt",
+    "mod",
+    "ceil",
+    "floor",
+    "trunc",
+    "max_",
+    "min_",
+    "avg",
 ]

--- a/src/rhosocial/activerecord/backend/impl/mysql/functions/math_enhanced.py
+++ b/src/rhosocial/activerecord/backend/impl/mysql/functions/math_enhanced.py
@@ -1,0 +1,378 @@
+# src/rhosocial/activerecord/backend/impl/mysql/functions/math_enhanced.py
+"""
+MySQL enhanced math function factories.
+
+Additional mathematical functions beyond the basic math module.
+Includes: round, pow, power, sqrt, mod, ceil, floor, truncate, max, min, avg
+
+Functions: round_, pow, power, sqrt, mod, ceil, floor, trunc, max_, min_, avg
+"""
+
+from typing import Union, TYPE_CHECKING
+
+from rhosocial.activerecord.backend.expression import bases, core
+
+if TYPE_CHECKING:  # pragma: no cover
+    from rhosocial.activerecord.backend.dialect import SQLDialectBase
+
+
+def _convert_to_expression(
+    dialect: "SQLDialectBase",
+    expr: Union[str, "bases.BaseExpression"],
+) -> "bases.BaseExpression":
+    """
+    Helper function to convert an input value to an appropriate BaseExpression.
+
+    Args:
+        dialect: The SQL dialect instance
+        expr: The expression to convert
+
+    Returns:
+        A BaseExpression instance
+    """
+    if isinstance(expr, bases.BaseExpression):
+        return expr
+    elif isinstance(expr, (int, float)):
+        return core.Literal(dialect, expr)
+    elif isinstance(expr, str):
+        # Try to parse as number first
+        try:
+            return core.Literal(dialect, float(expr) if '.' in expr else int(expr))
+        except ValueError:
+            # Not a number, treat as column name
+            return core.Column(dialect, expr)
+    else:
+        return core.Column(dialect, expr)
+
+
+def round_(
+    dialect: "SQLDialectBase",
+    expr: Union[str, "bases.BaseExpression"],
+    precision: int = 0,
+) -> "core.FunctionCall":
+    """
+    Creates a ROUND function call.
+
+    Rounds a numeric value to the specified number of decimal places.
+
+    Usage:
+        - round_(dialect, Column("price")) -> ROUND("price")
+        - round_(dialect, Column("price"), 2) -> ROUND("price", 2)
+
+    Args:
+        dialect: The SQL dialect instance
+        expr: The numeric expression to round
+        precision: Number of decimal places (default 0)
+
+    Returns:
+        A FunctionCall instance representing the ROUND function
+
+    Version: All MySQL versions
+    """
+    target_expr = _convert_to_expression(dialect, expr)
+    precision_expr = core.Literal(dialect, precision)
+    return core.FunctionCall(dialect, "ROUND", target_expr, precision_expr)
+
+
+def pow(
+    dialect: "SQLDialectBase",
+    base: Union[str, "bases.BaseExpression"],
+    exponent: Union[str, "bases.BaseExpression"],
+) -> "core.FunctionCall":
+    """
+    Creates a POW function call.
+
+    Returns the value of base raised to the power of exponent.
+
+    Usage:
+        - pow(dialect, 2, 3) -> POW(2, 3)
+        - pow(dialect, Column("x"), 2) -> POW("x", 2)
+
+    Args:
+        dialect: The SQL dialect instance
+        base: The base value
+        exponent: The exponent value
+
+    Returns:
+        A FunctionCall instance representing the POW function
+
+    Version: All MySQL versions
+    """
+    base_expr = _convert_to_expression(dialect, base)
+    exp_expr = _convert_to_expression(dialect, exponent)
+    return core.FunctionCall(dialect, "POW", base_expr, exp_expr)
+
+
+def power(
+    dialect: "SQLDialectBase",
+    base: Union[str, "bases.BaseExpression"],
+    exponent: Union[str, "bases.BaseExpression"],
+) -> "core.FunctionCall":
+    """
+    Creates a POWER function call (alias for POW).
+
+    Returns the value of base raised to the power of exponent.
+
+    Usage:
+        - power(dialect, 2, 3) -> POWER(2, 3)
+        - power(dialect, Column("x"), 2) -> POWER("x", 2)
+
+    Args:
+        dialect: The SQL dialect instance
+        base: The base value
+        exponent: The exponent value
+
+    Returns:
+        A FunctionCall instance representing the POWER function
+
+    Version: All MySQL versions
+    """
+    base_expr = _convert_to_expression(dialect, base)
+    exp_expr = _convert_to_expression(dialect, exponent)
+    return core.FunctionCall(dialect, "POWER", base_expr, exp_expr)
+
+
+def sqrt(
+    dialect: "SQLDialectBase",
+    expr: Union[str, "bases.BaseExpression"],
+) -> "core.FunctionCall":
+    """
+    Creates a SQRT function call.
+
+    Returns the square root of the argument.
+
+    Usage:
+        - sqrt(dialect, 16) -> SQRT(16)
+        - sqrt(dialect, Column("value")) -> SQRT("value")
+
+    Args:
+        dialect: The SQL dialect instance
+        expr: The numeric expression
+
+    Returns:
+        A FunctionCall instance representing the SQRT function
+
+    Version: All MySQL versions
+    """
+    target_expr = _convert_to_expression(dialect, expr)
+    return core.FunctionCall(dialect, "SQRT", target_expr)
+
+
+def mod(
+    dialect: "SQLDialectBase",
+    dividend: Union[str, "bases.BaseExpression"],
+    divisor: Union[str, "bases.BaseExpression"],
+) -> "core.FunctionCall":
+    """
+    Creates a MOD function call.
+
+    Returns the remainder of dividend divided by divisor.
+
+    Usage:
+        - mod(dialect, 10, 3) -> MOD(10, 3)
+        - mod(dialect, Column("total"), 10) -> MOD("total", 10)
+
+    Args:
+        dialect: The SQL dialect instance
+        dividend: The dividend value
+        divisor: The divisor value
+
+    Returns:
+        A FunctionCall instance representing the MOD function
+
+    Version: All MySQL versions
+    """
+    dividend_expr = _convert_to_expression(dialect, dividend)
+    divisor_expr = _convert_to_expression(dialect, divisor)
+    return core.FunctionCall(dialect, "MOD", dividend_expr, divisor_expr)
+
+
+def ceil(
+    dialect: "SQLDialectBase",
+    expr: Union[str, "bases.BaseExpression"],
+) -> "core.FunctionCall":
+    """
+    Creates a CEIL function call.
+
+    Returns the smallest integer value not less than the argument.
+
+    Usage:
+        - ceil(dialect, 3.14) -> CEIL(3.14)
+        - ceil(dialect, Column("price")) -> CEIL("price")
+
+    Args:
+        dialect: The SQL dialect instance
+        expr: The numeric expression
+
+    Returns:
+        A FunctionCall instance representing the CEIL function
+
+    Version: All MySQL versions (CEILING is also available as alias)
+    """
+    target_expr = _convert_to_expression(dialect, expr)
+    return core.FunctionCall(dialect, "CEIL", target_expr)
+
+
+def floor(
+    dialect: "SQLDialectBase",
+    expr: Union[str, "bases.BaseExpression"],
+) -> "core.FunctionCall":
+    """
+    Creates a FLOOR function call.
+
+    Returns the largest integer value not greater than the argument.
+
+    Usage:
+        - floor(dialect, 3.14) -> FLOOR(3.14)
+        - floor(dialect, Column("price")) -> FLOOR("price")
+
+    Args:
+        dialect: The SQL dialect instance
+        expr: The numeric expression
+
+    Returns:
+        A FunctionCall instance representing the FLOOR function
+
+    Version: All MySQL versions
+    """
+    target_expr = _convert_to_expression(dialect, expr)
+    return core.FunctionCall(dialect, "FLOOR", target_expr)
+
+
+def trunc(
+    dialect: "SQLDialectBase",
+    expr: Union[str, "bases.BaseExpression"],
+    precision: int = 0,
+) -> "core.FunctionCall":
+    """
+    Creates a TRUNCATE function call.
+
+    Returns the value truncated to the specified number of decimal places.
+
+    Usage:
+        - trunc(dialect, 3.14) -> TRUNCATE(3.14, 0)
+        - trunc(dialect, 3.14, 2) -> TRUNCATE(3.14, 2)
+        - trunc(dialect, Column("price"), 2) -> TRUNCATE("price", 2)
+
+    Note:
+        MySQL uses TRUNCATE, not TRUNC (which is used by some other databases).
+
+    Args:
+        dialect: The SQL dialect instance
+        expr: The numeric expression to truncate
+        precision: Number of decimal places (default 0)
+
+    Returns:
+        A FunctionCall instance representing the TRUNCATE function
+
+    Version: All MySQL versions
+    """
+    target_expr = _convert_to_expression(dialect, expr)
+    precision_expr = core.Literal(dialect, precision)
+    return core.FunctionCall(dialect, "TRUNCATE", target_expr, precision_expr)
+
+
+def max_(
+    dialect: "SQLDialectBase",
+    *args: Union[str, "bases.BaseExpression"],
+) -> "core.FunctionCall":
+    """
+    Creates a GREATEST or MAX function call.
+
+    Returns the maximum value from the arguments.
+
+    Usage:
+        - max_(dialect, 1, 5, 3, 9, 2) -> GREATEST(1, 5, 3, 9, 2)
+        - max_(dialect, Column("a"), Column("b")) -> GREATEST("a", "b")
+
+    Note:
+        When called with a single column argument, uses MAX (aggregate).
+        When called with multiple arguments, uses GREATEST (scalar).
+
+    Args:
+        dialect: The SQL dialect instance
+        *args: The values to compare
+
+    Returns:
+        A FunctionCall instance representing GREATEST or MAX
+
+    Version: All MySQL versions
+    """
+    if len(args) == 1:
+        arg_expr = _convert_to_expression(dialect, args[0])
+        return core.FunctionCall(dialect, "MAX", arg_expr)
+    arg_exprs = [_convert_to_expression(dialect, arg) for arg in args]
+    return core.FunctionCall(dialect, "GREATEST", *arg_exprs)
+
+
+def min_(
+    dialect: "SQLDialectBase",
+    *args: Union[str, "bases.BaseExpression"],
+) -> "core.FunctionCall":
+    """
+    Creates a LEAST or MIN function call.
+
+    Returns the minimum value from the arguments.
+
+    Usage:
+        - min_(dialect, 1, 5, 3, 9, 2) -> LEAST(1, 5, 3, 9, 2)
+        - min_(dialect, Column("a"), Column("b")) -> LEAST("a", "b")
+
+    Note:
+        When called with a single column argument, uses MIN (aggregate).
+        When called with multiple arguments, uses LEAST (scalar).
+
+    Args:
+        dialect: The SQL dialect instance
+        *args: The values to compare
+
+    Returns:
+        A FunctionCall instance representing LEAST or MIN
+
+    Version: All MySQL versions
+    """
+    if len(args) == 1:
+        arg_expr = _convert_to_expression(dialect, args[0])
+        return core.FunctionCall(dialect, "MIN", arg_expr)
+    arg_exprs = [_convert_to_expression(dialect, arg) for arg in args]
+    return core.FunctionCall(dialect, "LEAST", *arg_exprs)
+
+
+def avg(
+    dialect: "SQLDialectBase",
+    expr: Union[str, "bases.BaseExpression"],
+) -> "core.FunctionCall":
+    """
+    Creates an AVG function call.
+
+    Returns the average value of the argument.
+
+    Usage:
+        - avg(dialect, Column("price")) -> AVG("price")
+
+    Args:
+        dialect: The SQL dialect instance
+        expr: The numeric expression
+
+    Returns:
+        A FunctionCall instance representing the AVG function
+
+    Version: All MySQL versions
+    """
+    target_expr = _convert_to_expression(dialect, expr)
+    return core.FunctionCall(dialect, "AVG", target_expr)
+
+
+__all__ = [
+    "round_",
+    "pow",
+    "power",
+    "sqrt",
+    "mod",
+    "ceil",
+    "floor",
+    "trunc",
+    "max_",
+    "min_",
+    "avg",
+]

--- a/tests/rhosocial/activerecord_mysql_test/feature/backend/test_mysql_math_enhanced_functions.py
+++ b/tests/rhosocial/activerecord_mysql_test/feature/backend/test_mysql_math_enhanced_functions.py
@@ -1,0 +1,270 @@
+# tests/rhosocial/activerecord_mysql_test/feature/backend/test_mysql_math_enhanced_functions.py
+"""
+Tests for MySQL-specific enhanced math functions.
+
+These include additional mathematical functions beyond the basic math module.
+"""
+from rhosocial.activerecord.backend.expression import Column
+from rhosocial.activerecord.backend.impl.mysql.dialect import MySQLDialect
+from rhosocial.activerecord.backend.impl.mysql.functions.math_enhanced import (
+    round_,
+    pow,
+    power,
+    sqrt,
+    mod,
+    ceil,
+    floor,
+    trunc,
+    max_,
+    min_,
+    avg,
+)
+
+
+class TestMySQLMathEnhancedFunctions:
+    """Tests for MySQL enhanced math functions."""
+
+    def test_round__default(self, mysql_dialect: MySQLDialect):
+        """Test round_() with default precision."""
+        result = round_(mysql_dialect, Column(mysql_dialect, "value"))
+        sql, _ = result.to_sql()
+        assert "ROUND(" in sql
+        assert "`value`" in sql
+
+    def test_round__with_precision(self, mysql_dialect: MySQLDialect):
+        """Test round_() with precision."""
+        result = round_(mysql_dialect, Column(mysql_dialect, "price"), 2)
+        sql, _ = result.to_sql()
+        assert "ROUND(" in sql
+
+    def test_round__with_literal(self, mysql_dialect: MySQLDialect):
+        """Test round_() with literal value."""
+        result = round_(mysql_dialect, 3.14159, 2)
+        sql, _ = result.to_sql()
+        assert "ROUND(" in sql
+
+    def test_pow(self, mysql_dialect: MySQLDialect):
+        """Test pow() function."""
+        result = pow(mysql_dialect, Column(mysql_dialect, "base"), 2)
+        sql, _ = result.to_sql()
+        assert "POW(" in sql
+
+    def test_pow_both_columns(self, mysql_dialect: MySQLDialect):
+        """Test pow() with both column references."""
+        result = pow(
+            mysql_dialect,
+            Column(mysql_dialect, "x"),
+            Column(mysql_dialect, "y")
+        )
+        sql, _ = result.to_sql()
+        assert "POW(" in sql
+
+    def test_power(self, mysql_dialect: MySQLDialect):
+        """Test power() function (alias for POW)."""
+        result = power(mysql_dialect, 2, 3)
+        sql, _ = result.to_sql()
+        assert "POWER(" in sql
+
+    def test_sqrt(self, mysql_dialect: MySQLDialect):
+        """Test sqrt() function."""
+        result = sqrt(mysql_dialect, Column(mysql_dialect, "value"))
+        sql, _ = result.to_sql()
+        assert "SQRT(" in sql
+        assert "`value`" in sql
+
+    def test_sqrt_with_literal(self, mysql_dialect: MySQLDialect):
+        """Test sqrt() with literal value."""
+        result = sqrt(mysql_dialect, 16)
+        sql, _ = result.to_sql()
+        assert "SQRT(" in sql
+
+    def test_mod(self, mysql_dialect: MySQLDialect):
+        """Test mod() function."""
+        result = mod(mysql_dialect, Column(mysql_dialect, "total"), 10)
+        sql, _ = result.to_sql()
+        assert "MOD(" in sql
+
+    def test_mod_both_columns(self, mysql_dialect: MySQLDialect):
+        """Test mod() with both column references."""
+        result = mod(
+            mysql_dialect,
+            Column(mysql_dialect, "dividend"),
+            Column(mysql_dialect, "divisor")
+        )
+        sql, _ = result.to_sql()
+        assert "MOD(" in sql
+
+    def test_ceil(self, mysql_dialect: MySQLDialect):
+        """Test ceil() function."""
+        result = ceil(mysql_dialect, Column(mysql_dialect, "value"))
+        sql, _ = result.to_sql()
+        assert "CEIL(" in sql
+        assert "`value`" in sql
+
+    def test_ceil_with_literal(self, mysql_dialect: MySQLDialect):
+        """Test ceil() with literal value."""
+        result = ceil(mysql_dialect, 3.14)
+        sql, _ = result.to_sql()
+        assert "CEIL(" in sql
+
+    def test_floor(self, mysql_dialect: MySQLDialect):
+        """Test floor() function."""
+        result = floor(mysql_dialect, Column(mysql_dialect, "value"))
+        sql, _ = result.to_sql()
+        assert "FLOOR(" in sql
+        assert "`value`" in sql
+
+    def test_floor_with_literal(self, mysql_dialect: MySQLDialect):
+        """Test floor() with literal value."""
+        result = floor(mysql_dialect, 3.14)
+        sql, _ = result.to_sql()
+        assert "FLOOR(" in sql
+
+    def test_trunc(self, mysql_dialect: MySQLDialect):
+        """Test trunc() function (becomes TRUNCATE in MySQL)."""
+        result = trunc(mysql_dialect, Column(mysql_dialect, "value"))
+        sql, _ = result.to_sql()
+        assert "TRUNCATE(" in sql
+        assert "`value`" in sql
+
+    def test_trunc_with_literal(self, mysql_dialect: MySQLDialect):
+        """Test trunc() with literal value."""
+        result = trunc(mysql_dialect, 3.14)
+        sql, _ = result.to_sql()
+        assert "TRUNCATE(" in sql
+
+    def test_trunc_with_precision(self, mysql_dialect: MySQLDialect):
+        """Test trunc() with precision."""
+        result = trunc(mysql_dialect, 3.14159, 2)
+        sql, _ = result.to_sql()
+        assert "TRUNCATE(" in sql
+
+    def test_max__two_args(self, mysql_dialect: MySQLDialect):
+        """Test max_() with two arguments (uses GREATEST)."""
+        result = max_(mysql_dialect, Column(mysql_dialect, "a"), Column(mysql_dialect, "b"))
+        sql, _ = result.to_sql()
+        assert "GREATEST(" in sql
+
+    def test_max__multiple_args(self, mysql_dialect: MySQLDialect):
+        """Test max_() with multiple arguments (uses GREATEST)."""
+        result = max_(
+            mysql_dialect,
+            Column(mysql_dialect, "a"),
+            Column(mysql_dialect, "b"),
+            Column(mysql_dialect, "c")
+        )
+        sql, _ = result.to_sql()
+        assert "GREATEST(" in sql
+
+    def test_max__with_literals(self, mysql_dialect: MySQLDialect):
+        """Test max_() with literal values (uses GREATEST)."""
+        result = max_(mysql_dialect, 1, 2, 3)
+        sql, _ = result.to_sql()
+        assert "GREATEST(" in sql
+
+    def test_max__single_arg(self, mysql_dialect: MySQLDialect):
+        """Test max_() with single column argument (uses MAX aggregate)."""
+        result = max_(mysql_dialect, Column(mysql_dialect, "value"))
+        sql, _ = result.to_sql()
+        assert "MAX(" in sql
+
+    def test_min__two_args(self, mysql_dialect: MySQLDialect):
+        """Test min_() with two arguments (uses LEAST)."""
+        result = min_(mysql_dialect, Column(mysql_dialect, "a"), Column(mysql_dialect, "b"))
+        sql, _ = result.to_sql()
+        assert "LEAST(" in sql
+
+    def test_min__multiple_args(self, mysql_dialect: MySQLDialect):
+        """Test min_() with multiple arguments (uses LEAST)."""
+        result = min_(
+            mysql_dialect,
+            Column(mysql_dialect, "a"),
+            Column(mysql_dialect, "b"),
+            Column(mysql_dialect, "c")
+        )
+        sql, _ = result.to_sql()
+        assert "LEAST(" in sql
+
+    def test_min__with_literals(self, mysql_dialect: MySQLDialect):
+        """Test min_() with literal values (uses LEAST)."""
+        result = min_(mysql_dialect, 1, 2, 3)
+        sql, _ = result.to_sql()
+        assert "LEAST(" in sql
+
+    def test_min__single_arg(self, mysql_dialect: MySQLDialect):
+        """Test min_() with single column argument (uses MIN aggregate)."""
+        result = min_(mysql_dialect, Column(mysql_dialect, "value"))
+        sql, _ = result.to_sql()
+        assert "MIN(" in sql
+
+    def test_avg(self, mysql_dialect: MySQLDialect):
+        """Test avg() aggregate function."""
+        result = avg(mysql_dialect, Column(mysql_dialect, "price"))
+        sql, _ = result.to_sql()
+        assert "AVG(" in sql
+        assert "`price`" in sql
+
+    def test_avg_with_literal(self, mysql_dialect: MySQLDialect):
+        """Test avg() with literal value."""
+        result = avg(mysql_dialect, 100)
+        sql, _ = result.to_sql()
+        assert "AVG(" in sql
+
+    def test_round__with_string_integer(self, mysql_dialect: MySQLDialect):
+        """Test round_() with string integer value."""
+        result = round_(mysql_dialect, "123", 2)
+        sql, _ = result.to_sql()
+        assert "ROUND(" in sql
+
+    def test_round__with_string_float(self, mysql_dialect: MySQLDialect):
+        """Test round_() with string float value."""
+        result = round_(mysql_dialect, "3.14159", 2)
+        sql, _ = result.to_sql()
+        assert "ROUND(" in sql
+
+    def test_round__with_string_column_name(self, mysql_dialect: MySQLDialect):
+        """Test round_() with non-numeric string treated as column."""
+        result = round_(mysql_dialect, "column_name", 2)
+        sql, _ = result.to_sql()
+        assert "ROUND(" in sql
+        assert "`column_name`" in sql
+
+    def test_pow_with_string_integer(self, mysql_dialect: MySQLDialect):
+        """Test pow() with string integer exponent."""
+        result = pow(mysql_dialect, Column(mysql_dialect, "base"), "2")
+        sql, _ = result.to_sql()
+        assert "POW(" in sql
+
+    def test_sqrt_with_string_integer(self, mysql_dialect: MySQLDialect):
+        """Test sqrt() with string integer value."""
+        result = sqrt(mysql_dialect, "16")
+        sql, _ = result.to_sql()
+        assert "SQRT(" in sql
+
+    def test_mod_with_string_divisor(self, mysql_dialect: MySQLDialect):
+        """Test mod() with string divisor."""
+        result = mod(mysql_dialect, Column(mysql_dialect, "total"), "10")
+        sql, _ = result.to_sql()
+        assert "MOD(" in sql
+
+    def test_max__with_string_literals(self, mysql_dialect: MySQLDialect):
+        """Test max_() with non-numeric string values (treated as columns in GREATEST)."""
+        result = max_(mysql_dialect, "a", "b", "c")
+        sql, _ = result.to_sql()
+        assert "GREATEST(" in sql
+        # Non-numeric strings should be treated as column names and quoted with backticks
+        assert "`a`" in sql
+
+    def test_min__with_string_literals(self, mysql_dialect: MySQLDialect):
+        """Test min_() with non-numeric string values (treated as columns in LEAST)."""
+        result = min_(mysql_dialect, "a", "b", "c")
+        sql, _ = result.to_sql()
+        assert "LEAST(" in sql
+        # Non-numeric strings should be treated as column names and quoted with backticks
+        assert "`a`" in sql
+
+    def test_avg_with_string_literal(self, mysql_dialect: MySQLDialect):
+        """Test avg() with string numeric value."""
+        result = avg(mysql_dialect, "100")
+        sql, _ = result.to_sql()
+        assert "AVG(" in sql


### PR DESCRIPTION
## Description

<!--
Please include a summary of the new feature and its motivation.
Describe the problem it solves or the new capability it provides.
List any dependencies that are required for this change.
-->

Adds MySQL math enhanced functions with proper Python-safe naming to avoid conflicts with built-in functions:

- `round_` - MySQL ROUND function (renamed to avoid Python builtin conflict)
- `pow`, `power` - MySQL POWER function with alias
- `sqrt` - MySQL SQRT function
- `mod` - MySQL MOD function
- `ceil` - MySQL CEIL/CEILING functions
- `floor` - MySQL FLOOR function
- `trunc` - MySQL TRUNCATE function
- `max_`, `min_` - GREATEST/LEAST for multi-argument, MAX/MIN for aggregate
- `avg` - AVG aggregate function

## Type of change

<!--
Please delete options that are not relevant.
Remember to follow the Conventional Commits specification.
-->

- [x] `feat`: A new feature
- [ ] `docs`: Documentation only changes (if related to the new feature)
- [ ] `perf`: A code change that improves performance (if part of the feature)
- [ ] `test`: Adding missing tests or correcting existing tests (for the new feature)
- [ ] `chore`: Changes to the build process or auxiliary tools and libraries suchs as documentation generation (if related to the new feature)
- [ ] `ci`: Changes to our CI configuration files and scripts (if related to the new feature)
- [ ] `build`: Changes that affect the build system or external dependencies (if related to the new feature)
- [ ] `revert`: Reverts a previous commit

## Breaking Change

<!--
Does this PR introduce a breaking change?
- If YES, please describe the impact and migration path for existing applications.
- If NO, please indicate N/A.
-->

- [ ] Yes
- [x] No

(If Yes, please describe the impact and migration path below):

**Applicable `rhosocial-activerecord` Version Range:**
<!-- Specify the version range of rhosocial-activerecord that this change is compatible with (e.g., ">=1.0.0,<2.0.0"). -->

`>=0.9.0,<2.0.0`

## Related Repositories/Packages

<!--
If this change affects other repositories in the rhosocial-activerecord ecosystem (e.g., testsuite, mysql, postgres),
please list them and describe the coordinated changes needed.
-->

N/A - This is a MySQL-specific backend enhancement.

## Testing

<!--
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
Also, list any relevant configuration details (e.g., MySQL version, Python version).
-->

- [x] I have added new tests to cover my changes.
- [ ] I have updated existing tests to reflect my changes.
- [ ] All existing tests pass.
- [ ] This change has been tested on [specify backend/DB versions].

**Test Plan:**
`pytest tests/rhosocial/activerecord_test/backend/mysql/test_mysql_math_enhanced_functions.py`

## Checklist

<!--
Go over all the following points, and put an `x` in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [x] My code follows the project's [code style guidelines](./.gemini/code_style.md).
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation (Docstrings, `README.md`, etc.).
- [x] My changes generate no new warnings.
- [ ] I have added a [Changelog fragment](./.gemini/version_control.md#5-changelog-management-with-towncrier) (`changelog.d/<issue_number>.<type>.md`).
- [x] I have verified that my changes do not introduce SQL injection vulnerabilities.
- [x] I have checked for potential performance regressions.

## Additional Notes

<!-- Any additional information, context, or questions for reviewers. -->

This PR is a follow-up to the previous refactoring PR #28 which restructured functions into submodules by category. This PR adds the math enhanced functions to the new structure.

### Commit History

```
659d3f2 feat(mysql): add math enhanced functions with proper naming
d997a9c refactor(mysql): restructure functions into submodules by category (#28)
```
