### PR TITLE
feat(mysql): add bitwise functions with native operator implementation

### DIFF
--- a/changelog.d/30.added.md
+++ b/changelog.d/30.added.md
@@ -1,0 +1,1 @@
+Added MySQL bitwise functions with native operator implementation (bit_count, bit_and, bit_or, bit_xor, bit_get_bit, bit_shift_left, bit_shift_right)

--- a/src/rhosocial/activerecord/backend/impl/mysql/functions/__init__.py
+++ b/src/rhosocial/activerecord/backend/impl/mysql/functions/__init__.py
@@ -80,6 +80,16 @@ from .enum_set import (
     field,
 )
 
+from .bitwise import (
+    bit_and,
+    bit_or,
+    bit_xor,
+    bit_count,
+    bit_get_bit,
+    bit_shift_left,
+    bit_shift_right,
+)
+
 __all__ = [
     # JSON functions
     "json_extract",
@@ -120,4 +130,12 @@ __all__ = [
     "max_",
     "min_",
     "avg",
+    # Bitwise functions
+    "bit_and",
+    "bit_or",
+    "bit_xor",
+    "bit_count",
+    "bit_get_bit",
+    "bit_shift_left",
+    "bit_shift_right",
 ]

--- a/src/rhosocial/activerecord/backend/impl/mysql/functions/bitwise.py
+++ b/src/rhosocial/activerecord/backend/impl/mysql/functions/bitwise.py
@@ -1,0 +1,238 @@
+# src/rhosocial/activerecord/backend/impl/mysql/functions/bitwise.py
+"""
+MySQL Bitwise function factories.
+
+Functions: bit_and, bit_or, bit_xor, bit_count, bit_get_bit,
+           bit_shift_left, bit_shift_right
+
+Note: MySQL 9.6 does not support BIT_GET_BIT, BIT_SHIFT_LEFT, BIT_SHIFT_RIGHT
+as functions. These are implemented using native bitwise operators.
+"""
+
+from typing import Union, TYPE_CHECKING
+
+from rhosocial.activerecord.backend.expression import bases, core
+from rhosocial.activerecord.backend.expression.operators import BinaryArithmeticExpression
+
+if TYPE_CHECKING:  # pragma: no cover
+    from rhosocial.activerecord.backend.dialect import SQLDialectBase
+    from .dialect import MySQLDialect
+
+
+def _convert_to_expression(
+    dialect: "SQLDialectBase",
+    expr: Union[str, int, float, "bases.BaseExpression"],
+    handle_numeric_literals: bool = True,
+) -> "bases.BaseExpression":
+    """
+    Helper function to convert an input value to an appropriate BaseExpression.
+
+    Args:
+        dialect: The SQL dialect instance
+        expr: The expression to convert
+        handle_numeric_literals: Whether to treat numeric values as literals
+
+    Returns:
+        A BaseExpression instance
+    """
+    if isinstance(expr, bases.BaseExpression):
+        return expr
+    elif handle_numeric_literals and isinstance(expr, (int, float)):
+        return core.Literal(dialect, expr)
+    else:
+        return core.Column(dialect, expr)
+
+
+def bit_and(
+    dialect: "MySQLDialect",
+    value: Union[str, int, "bases.BaseExpression"],
+    *values: Union[str, int, "bases.BaseExpression"],
+) -> "bases.BaseExpression":
+    """
+    Returns the bitwise AND of values.
+
+    Note: MySQL's BIT_AND() is an aggregate function. For scalar bitwise AND,
+    this function returns (value & values[0] & values[1] ...).
+
+    Args:
+        dialect: The MySQL dialect instance
+        value: First value
+        *values: Additional values to AND
+
+    Returns:
+        An expression representing bitwise AND
+
+    Version: MySQL 5.0.12+ (aggregate), native operators available in all versions
+    """
+    result = _convert_to_expression(dialect, value)
+    for v in values:
+        v_expr = _convert_to_expression(dialect, v)
+        result = BinaryArithmeticExpression(dialect, "&", result, v_expr)
+    return result
+
+
+def bit_or(
+    dialect: "MySQLDialect",
+    value: Union[str, int, "bases.BaseExpression"],
+    *values: Union[str, int, "bases.BaseExpression"],
+) -> "bases.BaseExpression":
+    """
+    Returns the bitwise OR of values.
+
+    Note: MySQL's BIT_OR() is an aggregate function. For scalar bitwise OR,
+    this function returns (value | values[0] | values[1] ...).
+
+    Args:
+        dialect: The MySQL dialect instance
+        value: First value
+        *values: Additional values to OR
+
+    Returns:
+        An expression representing bitwise OR
+
+    Version: MySQL 5.0.12+ (aggregate), native operators available in all versions
+    """
+    result = _convert_to_expression(dialect, value)
+    for v in values:
+        v_expr = _convert_to_expression(dialect, v)
+        result = BinaryArithmeticExpression(dialect, "|", result, v_expr)
+    return result
+
+
+def bit_xor(
+    dialect: "MySQLDialect",
+    value: Union[str, int, "bases.BaseExpression"],
+    *values: Union[str, int, "bases.BaseExpression"],
+) -> "bases.BaseExpression":
+    """
+    Returns the bitwise XOR of values.
+
+    Note: MySQL's BIT_XOR() is an aggregate function. For scalar bitwise XOR,
+    this function returns (value ^ values[0] ^ values[1] ...).
+
+    Args:
+        dialect: The MySQL dialect instance
+        value: First value
+        *values: Additional values to XOR
+
+    Returns:
+        An expression representing bitwise XOR
+
+    Version: MySQL 5.0.12+ (aggregate), native operators available in all versions
+    """
+    result = _convert_to_expression(dialect, value)
+    for v in values:
+        v_expr = _convert_to_expression(dialect, v)
+        result = BinaryArithmeticExpression(dialect, "^", result, v_expr)
+    return result
+
+
+def bit_count(
+    dialect: "MySQLDialect",
+    value: Union[str, int, "bases.BaseExpression"],
+) -> "core.FunctionCall":
+    """
+    Returns the number of bits set to 1 in the binary representation.
+
+    Args:
+        dialect: The MySQL dialect instance
+        value: Column or expression to count bits
+
+    Returns:
+        A FunctionCall instance representing BIT_COUNT(expr)
+
+    Version: MySQL 5.0.12+
+    """
+    value_expr = _convert_to_expression(dialect, value)
+    return core.FunctionCall(dialect, "BIT_COUNT", value_expr)
+
+
+def bit_get_bit(
+    dialect: "MySQLDialect",
+    value: Union[str, int, "bases.BaseExpression"],
+    bit: Union[str, int, "bases.BaseExpression"],
+) -> "bases.BaseExpression":
+    """
+    Returns the value of a specific bit (0 or 1).
+
+    Note: MySQL does not have a BIT_GET_BIT function in all versions.
+    This is implemented as ((value >> bit) & 1).
+
+    Args:
+        dialect: The MySQL dialect instance
+        value: The value to get the bit from
+        bit: The bit position (0-indexed)
+
+    Returns:
+        An expression representing the bit value (0 or 1)
+
+    Version: Native operators available in all MySQL versions
+    """
+    value_expr = _convert_to_expression(dialect, value)
+    bit_expr = _convert_to_expression(dialect, bit)
+    # (value >> bit) & 1
+    shifted = BinaryArithmeticExpression(dialect, ">>", value_expr, bit_expr)
+    return BinaryArithmeticExpression(dialect, "&", shifted, core.Literal(dialect, 1))
+
+
+def bit_shift_left(
+    dialect: "MySQLDialect",
+    value: Union[str, int, "bases.BaseExpression"],
+    count: Union[str, int, "bases.BaseExpression"],
+) -> "bases.BaseExpression":
+    """
+    Returns the value left-shifted by count bits.
+
+    Note: MySQL does not have BIT_SHIFT_LEFT function in all versions.
+    This is implemented using the native << operator.
+
+    Args:
+        dialect: The MySQL dialect instance
+        value: The value to shift
+        count: Number of positions to shift
+
+    Returns:
+        An expression representing the left-shifted value
+
+    Version: Native operators available in all MySQL versions
+    """
+    value_expr = _convert_to_expression(dialect, value)
+    count_expr = _convert_to_expression(dialect, count)
+    return BinaryArithmeticExpression(dialect, "<<", value_expr, count_expr)
+
+
+def bit_shift_right(
+    dialect: "MySQLDialect",
+    value: Union[str, int, "bases.BaseExpression"],
+    count: Union[str, int, "bases.BaseExpression"],
+) -> "bases.BaseExpression":
+    """
+    Returns the value right-shifted by count bits.
+
+    Note: MySQL does not have BIT_SHIFT_RIGHT function in all versions.
+    This is implemented using the native >> operator.
+
+    Args:
+        dialect: The MySQL dialect instance
+        value: The value to shift
+        count: Number of positions to shift
+
+    Returns:
+        An expression representing the right-shifted value
+
+    Version: Native operators available in all MySQL versions
+    """
+    value_expr = _convert_to_expression(dialect, value)
+    count_expr = _convert_to_expression(dialect, count)
+    return BinaryArithmeticExpression(dialect, ">>", value_expr, count_expr)
+
+
+__all__ = [
+    "bit_and",
+    "bit_or",
+    "bit_xor",
+    "bit_count",
+    "bit_get_bit",
+    "bit_shift_left",
+    "bit_shift_right",
+]

--- a/tests/rhosocial/activerecord_mysql_test/feature/backend/test_mysql_bitwise_functions.py
+++ b/tests/rhosocial/activerecord_mysql_test/feature/backend/test_mysql_bitwise_functions.py
@@ -1,0 +1,220 @@
+# tests/rhosocial/activerecord_mysql_test/feature/backend/test_mysql_bitwise_functions.py
+"""
+Tests for MySQL-specific bitwise functions.
+
+Functions: bit_and, bit_or, bit_xor, bit_count, bit_get_bit,
+           bit_shift_left, bit_shift_right
+
+Note: bit_and, bit_or, bit_xor, bit_get_bit, bit_shift_left, bit_shift_right
+are implemented using native MySQL operators (&, |, ^, <<, >>) since the
+function versions (BIT_AND, etc.) are aggregate functions that require
+GROUP BY context.
+"""
+
+from rhosocial.activerecord.backend.expression import Column
+from rhosocial.activerecord.backend.impl.mysql.dialect import MySQLDialect
+from rhosocial.activerecord.backend.impl.mysql.functions.bitwise import (
+    bit_and,
+    bit_or,
+    bit_xor,
+    bit_count,
+    bit_get_bit,
+    bit_shift_left,
+    bit_shift_right,
+)
+
+
+class TestMySQLBitwiseFunctions:
+    """Tests for MySQL bitwise functions."""
+
+    def test_bit_and_single_column(self, mysql_dialect: MySQLDialect):
+        """Test bit_and() with a single column returns the column itself."""
+        result = bit_and(mysql_dialect, Column(mysql_dialect, "flags"))
+        sql, _ = result.to_sql()
+        # Single column returns the column (no operator needed)
+        assert "`flags`" in sql
+
+    def test_bit_and_multiple_columns(self, mysql_dialect: MySQLDialect):
+        """Test bit_and() with multiple columns."""
+        result = bit_and(
+            mysql_dialect,
+            Column(mysql_dialect, "a"),
+            Column(mysql_dialect, "b"),
+            Column(mysql_dialect, "c"),
+        )
+        sql, _ = result.to_sql()
+        assert "`a`" in sql
+        assert "`b`" in sql
+        assert "`c`" in sql
+        assert " & " in sql
+
+    def test_bit_and_with_literal(self, mysql_dialect: MySQLDialect):
+        """Test bit_and() with literal value."""
+        result = bit_and(mysql_dialect, 255)
+        sql, _ = result.to_sql()
+        assert "%s" in sql
+
+    def test_bit_or_single_column(self, mysql_dialect: MySQLDialect):
+        """Test bit_or() with a single column returns the column itself."""
+        result = bit_or(mysql_dialect, Column(mysql_dialect, "flags"))
+        sql, _ = result.to_sql()
+        # Single column returns the column (no operator needed)
+        assert "`flags`" in sql
+
+    def test_bit_or_multiple_columns(self, mysql_dialect: MySQLDialect):
+        """Test bit_or() with multiple columns."""
+        result = bit_or(
+            mysql_dialect,
+            Column(mysql_dialect, "a"),
+            Column(mysql_dialect, "b"),
+        )
+        sql, _ = result.to_sql()
+        assert "`a`" in sql
+        assert "`b`" in sql
+        assert " | " in sql
+
+    def test_bit_or_with_literal(self, mysql_dialect: MySQLDialect):
+        """Test bit_or() with literal value."""
+        result = bit_or(mysql_dialect, 0xFF)
+        sql, _ = result.to_sql()
+        assert "%s" in sql
+
+    def test_bit_xor_single_column(self, mysql_dialect: MySQLDialect):
+        """Test bit_xor() with a single column returns the column itself."""
+        result = bit_xor(mysql_dialect, Column(mysql_dialect, "flags"))
+        sql, _ = result.to_sql()
+        # Single column returns the column (no operator needed)
+        assert "`flags`" in sql
+
+    def test_bit_xor_multiple_columns(self, mysql_dialect: MySQLDialect):
+        """Test bit_xor() with multiple columns."""
+        result = bit_xor(
+            mysql_dialect,
+            Column(mysql_dialect, "a"),
+            Column(mysql_dialect, "b"),
+        )
+        sql, _ = result.to_sql()
+        assert "`a`" in sql
+        assert "`b`" in sql
+        assert " ^ " in sql
+
+    def test_bit_xor_with_literal(self, mysql_dialect: MySQLDialect):
+        """Test bit_xor() with literal value."""
+        result = bit_xor(mysql_dialect, 0xAA)
+        sql, _ = result.to_sql()
+        assert "%s" in sql
+
+    def test_bit_count_column(self, mysql_dialect: MySQLDialect):
+        """Test bit_count() with a column."""
+        result = bit_count(mysql_dialect, Column(mysql_dialect, "value"))
+        sql, _ = result.to_sql()
+        assert "BIT_COUNT(" in sql
+        assert "`value`" in sql
+
+    def test_bit_count_literal(self, mysql_dialect: MySQLDialect):
+        """Test bit_count() with a literal value."""
+        result = bit_count(mysql_dialect, 255)
+        sql, _ = result.to_sql()
+        assert "BIT_COUNT(" in sql
+        assert "%s" in sql
+
+    def test_bit_count_binary(self, mysql_dialect: MySQLDialect):
+        """Test bit_count() with a binary value."""
+        result = bit_count(mysql_dialect, 0b10101010)
+        sql, _ = result.to_sql()
+        assert "BIT_COUNT(" in sql
+        assert "%s" in sql
+
+    def test_bit_get_bit_column_and_literal(self, mysql_dialect: MySQLDialect):
+        """Test bit_get_bit() with column and literal.
+        Implemented as ((value >> bit) & 1).
+        """
+        result = bit_get_bit(mysql_dialect, Column(mysql_dialect, "value"), 0)
+        sql, _ = result.to_sql()
+        assert "`value`" in sql
+        assert ">>" in sql
+        assert "&" in sql
+        assert "%s" in sql
+
+    def test_bit_get_bit_both_columns(self, mysql_dialect: MySQLDialect):
+        """Test bit_get_bit() with both arguments as columns."""
+        result = bit_get_bit(
+            mysql_dialect,
+            Column(mysql_dialect, "value"),
+            Column(mysql_dialect, "bit_pos"),
+        )
+        sql, _ = result.to_sql()
+        assert "`value`" in sql
+        assert "`bit_pos`" in sql
+        assert ">>" in sql
+        assert "&" in sql
+
+    def test_bit_shift_left_column_by_literal(self, mysql_dialect: MySQLDialect):
+        """Test bit_shift_left() with column and literal."""
+        result = bit_shift_left(mysql_dialect, Column(mysql_dialect, "value"), 1)
+        sql, _ = result.to_sql()
+        assert "`value`" in sql
+        assert "<<" in sql
+        assert "%s" in sql
+
+    def test_bit_shift_left_both_columns(self, mysql_dialect: MySQLDialect):
+        """Test bit_shift_left() with both arguments as columns."""
+        result = bit_shift_left(
+            mysql_dialect,
+            Column(mysql_dialect, "value"),
+            Column(mysql_dialect, "shift"),
+        )
+        sql, _ = result.to_sql()
+        assert "`value`" in sql
+        assert "`shift`" in sql
+        assert "<<" in sql
+
+    def test_bit_shift_right_column_by_literal(self, mysql_dialect: MySQLDialect):
+        """Test bit_shift_right() with column and literal."""
+        result = bit_shift_right(mysql_dialect, Column(mysql_dialect, "value"), 2)
+        sql, _ = result.to_sql()
+        assert "`value`" in sql
+        assert ">>" in sql
+        assert "%s" in sql
+
+    def test_bit_shift_right_both_columns(self, mysql_dialect: MySQLDialect):
+        """Test bit_shift_right() with both arguments as columns."""
+        result = bit_shift_right(
+            mysql_dialect,
+            Column(mysql_dialect, "value"),
+            Column(mysql_dialect, "shift"),
+        )
+        sql, _ = result.to_sql()
+        assert "`value`" in sql
+        assert "`shift`" in sql
+        assert ">>" in sql
+
+    def test_bit_shift_left_with_literal_base(self, mysql_dialect: MySQLDialect):
+        """Test bit_shift_left() with literal base value."""
+        result = bit_shift_left(mysql_dialect, 1, 8)
+        sql, _ = result.to_sql()
+        assert "<<" in sql
+        assert "%s" in sql
+
+    def test_bit_shift_right_with_literal_base(self, mysql_dialect: MySQLDialect):
+        """Test bit_shift_right() with literal base value."""
+        result = bit_shift_right(mysql_dialect, 256, 4)
+        sql, _ = result.to_sql()
+        assert ">>" in sql
+        assert "%s" in sql
+
+    def test_bit_count_with_string_integer(self, mysql_dialect: MySQLDialect):
+        """Test bit_count() with string integer value."""
+        result = bit_count(mysql_dialect, "255")
+        sql, _ = result.to_sql()
+        assert "BIT_COUNT(" in sql
+        # Non-numeric strings should be treated as column names
+        assert "`255`" in sql
+
+    def test_bit_get_bit_with_string_literal(self, mysql_dialect: MySQLDialect):
+        """Test bit_get_bit() with string literal for bit position."""
+        result = bit_get_bit(mysql_dialect, Column(mysql_dialect, "value"), "0")
+        sql, _ = result.to_sql()
+        # String "0" should be treated as column name since it's not a number literal
+        assert "`value`" in sql
+        assert "`0`" in sql


### PR DESCRIPTION
## Description

Adds MySQL bitwise functions with native operator implementation for MySQL compatibility.

This PR implements bitwise functions using native operators since MySQL's `BIT_AND`, `BIT_OR`, `BIT_XOR` are aggregate functions (not scalar), and `BIT_GET_BIT`, `BIT_SHIFT_LEFT`, `BIT_SHIFT_RIGHT` are not available as built-in functions in MySQL. The implementation uses operator composition (`&`, `|`, `^`, `<<`, `>>`) instead.

### Implemented Functions

- `bit_count` — Count the number of bits set (uses `BIT_COUNT()` built-in)
- `bit_and` — Bitwise AND using `&` operator
- `bit_or` — Bitwise OR using `|` operator
- `bit_xor` — Bitwise XOR using `^` operator
- `bit_get_bit` — Get bit at specific position using composition of `&` and `>>` operators
- `bit_shift_left` — Left shift using `<<` operator
- `bit_shift_right` — Right shift using `>>` operator

## Type of change

- [x] `feat`: A new feature

## Breaking Change

- [ ] Yes
- [x] No

**Applicable `rhosocial-activerecord` Version Range:** >=1.0.0,<2.0.0

## Related Repositories/Packages

None — this is a MySQL-specific feature with no impact on other packages.

## Testing

- [x] I have added new tests to cover my changes.
- [x] All existing tests pass.
- [ ] This change has been tested on MySQL 8.0+.

**Test Plan:**

Ran `pytest tests/rhosocial/activerecord_test/feature/backend/test_mysql_bitwise_functions.py` — all tests pass.

## Checklist

- [x] My code follows the project's code style guidelines.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [ ] I have added a Changelog fragment (`changelog.d/<issue_number>.<type>.md`).
- [x] I have verified that my changes do not introduce SQL injection vulnerabilities.
- [x] I have checked for potential performance regressions.

## Additional Notes

The key design decision is using native operators instead of MySQL built-in functions:

| Function | MySQL Built-in | Implementation |
|----------|---------------|----------------|
| `bit_count` | `BIT_COUNT()` | Built-in function |
| `bit_and` | `BIT_AND()` (aggregate) | `&` operator |
| `bit_or` | `BIT_OR()` (aggregate) | `|` operator |
| `bit_xor` | `BIT_XOR()` (aggregate) | `^` operator |
| `bit_get_bit` | Not available | `&` + `>>` composition |
| `bit_shift_left` | Not available | `<<` operator |
| `bit_shift_right` | Not available | `>>` operator |