### PR TITLE
feat(dialect): require version adaptation before using MySQL dialect

### DIFF
--- a/changelog.d/39.changed.md
+++ b/changelog.d/39.changed.md
@@ -1,0 +1,1 @@
+Changed MySQLDialect to default to version=None instead of fixed version, requiring introspect_and_adapt() or explicit version before version-dependent features can be used.

--- a/src/rhosocial/activerecord/backend/impl/mysql/async_backend.py
+++ b/src/rhosocial/activerecord/backend/impl/mysql/async_backend.py
@@ -43,10 +43,11 @@ class AsyncMySQLBackend(AsyncExplainBackendMixin, IntrospectorBackendMixin, MySQ
         Args:
             version: Expected MySQL server version tuple (major, minor, patch).
                     Used for dialect and type adapter initialization.
-                    Defaults to (8, 0, 0). Can be passed as 'version' in kwargs.
+                    If None, actual version will be detected via introspect_and_adapt().
+                    Can be passed as 'version' in kwargs.
         """
         # Extract version from kwargs if provided
-        version = kwargs.pop('version', None) or (8, 0, 0)
+        version = kwargs.pop('version', None)
 
         # Ensure we have proper MySQL configuration
         connection_config = kwargs.get('connection_config')

--- a/src/rhosocial/activerecord/backend/impl/mysql/backend.py
+++ b/src/rhosocial/activerecord/backend/impl/mysql/backend.py
@@ -42,10 +42,11 @@ class MySQLBackend(SyncExplainBackendMixin, IntrospectorBackendMixin, MySQLBacke
         Args:
             version: Expected MySQL server version tuple (major, minor, patch).
                     Used for dialect and type adapter initialization.
-                    Defaults to (8, 0, 0). Can be passed as 'version' in kwargs.
+                    If None, actual version will be detected via introspect_and_adapt().
+                    Can be passed as 'version' in kwargs.
         """
         # Extract version from kwargs if provided
-        version = kwargs.pop('version', None) or (8, 0, 0)
+        version = kwargs.pop('version', None)
 
         # Ensure we have proper MySQL configuration
         connection_config = kwargs.get('connection_config')

--- a/src/rhosocial/activerecord/backend/impl/mysql/dialect.py
+++ b/src/rhosocial/activerecord/backend/impl/mysql/dialect.py
@@ -201,15 +201,19 @@ class MySQLDialect(
     - MERGE statement (not supported, use ON DUPLICATE KEY UPDATE or REPLACE)
     """
 
-    def __init__(self, version: Tuple[int, int, int] = (8, 0, 0)):
+    def __init__(self, version: Optional[Tuple[int, int, int]] = None):
         """
         Initialize MySQL dialect with specific version.
 
         Args:
-            version: MySQL version tuple (major, minor, patch)
+            version: MySQL version tuple (major, minor, patch).
+                If None, the dialect must be adapted via
+                backend.introspect_and_adapt() before version-dependent
+                features can be used.
         """
-        self.version = version
         super().__init__()
+        if version is not None:
+            self.version = version
 
     def get_parameter_placeholder(self, position: int = 0) -> str:
         """MySQL uses '%s' for placeholders."""

--- a/tests/rhosocial/activerecord_mysql_test/feature/backend/conftest.py
+++ b/tests/rhosocial/activerecord_mysql_test/feature/backend/conftest.py
@@ -288,4 +288,6 @@ def check_protocol_requirements(request):
 def mysql_dialect():
     """Fixture providing MySQLDialect instance for testing transaction expressions."""
     from rhosocial.activerecord.backend.impl.mysql.dialect import MySQLDialect
-    return MySQLDialect()
+    dialect = MySQLDialect()
+    dialect.version = (8, 0, 0)
+    return dialect

--- a/tests/rhosocial/activerecord_mysql_test/feature/backend/test_dialect_function_support.py
+++ b/tests/rhosocial/activerecord_mysql_test/feature/backend/test_dialect_function_support.py
@@ -14,21 +14,21 @@ class TestMySQLFunctionSupportBasic:
 
     def test_supports_functions_returns_dict(self):
         """Test that supports_functions returns a dictionary."""
-        dialect = MySQLDialect()
+        dialect = MySQLDialect((8, 0, 0))
         result = dialect.supports_functions()
         assert isinstance(result, dict)
         assert len(result) > 0
 
     def test_supports_functions_all_values_are_bool(self):
         """Test that all values in the returned dict are booleans."""
-        dialect = MySQLDialect()
+        dialect = MySQLDialect((8, 0, 0))
         result = dialect.supports_functions()
         for func_name, supported in result.items():
             assert isinstance(supported, bool), f"Value for {func_name} is not bool"
 
     def test_core_functions_always_supported(self):
         """Test that core functions are marked as supported."""
-        dialect = MySQLDialect()
+        dialect = MySQLDialect((8, 0, 0))
         result = dialect.supports_functions()
         core_functions = ["count", "sum_", "avg", "min_", "max_", "coalesce", "nullif"]
         for func in core_functions:
@@ -82,7 +82,7 @@ class TestMySQLFunctionSupportVersionDependent:
 
     def test_always_available_functions(self):
         """Test functions that are available in all MySQL versions."""
-        dialect = MySQLDialect()
+        dialect = MySQLDialect((8, 0, 0))
         result = dialect.supports_functions()
 
         always_available = [
@@ -115,7 +115,7 @@ class TestMySQLFunctionSupportPrivateMethod:
 
     def test_unknown_function_returns_true(self):
         """Test that unknown functions return True (no restriction)."""
-        dialect = MySQLDialect()
+        dialect = MySQLDialect((8, 0, 0))
         result = dialect._is_mysql_function_supported("unknown_function_xyz")
         assert result is True
 
@@ -143,7 +143,7 @@ class TestMySQLFunctionSupportIntegration:
 
     def test_function_dict_contains_both_core_and_backend_functions(self):
         """Test that the result contains both core and MySQL-specific functions."""
-        dialect = MySQLDialect()
+        dialect = MySQLDialect((8, 0, 0))
         result = dialect.supports_functions()
 
         assert any(func in result for func in ["count", "sum_", "avg"])


### PR DESCRIPTION

## Description

`MySQLDialect` now defaults to `version=None`, requiring `introspect_and_adapt()` or explicit version before version-dependent features can be used. This prevents silent SQL errors from incorrect version assumptions.

**Problem**: Backend dialects had default versions that could mismatch actual server capabilities, causing silent SQL errors when using features the server doesn't support.

**Solution**: Part of the dialect version guarding initiative across the rhosocial-activerecord ecosystem. Dialects now default to `None` version and throw `DialectNotAdaptedException` at use time.

**Key Changes**:
- Change `MySQLDialect.__init__` default version to `None`
- Remove fallback `(8, 0, 0)` from backend version extraction
- Update tests to use explicit version `(8, 0, 0)`

## Type of change

- [x] `feat`: A new feature
- [ ] `docs`: Documentation only changes
- [ ] `perf`: A code change that improves performance
- [x] `test`: Adding missing tests or correcting existing tests
- [ ] `chore`: Changes to the build process or auxiliary tools
- [ ] `ci`: Changes to our CI configuration files and scripts
- [ ] `build`: Changes that affect the build system or external dependencies
- [ ] `revert`: Reverts a previous commit

## Breaking Change

- [ ] Yes
- [x] No

**Impact on End-Users:**
No backward-incompatible changes are expected for typical end-user applications. The `context()` and `configure()` methods continue to work as before, automatically calling `introspect_and_adapt()`.

**Impact on Backend Developers:**
Custom backend implementations must ensure dialect version is set either:
1. Explicitly via constructor: `MySQLDialect(version=(X, Y, Z))`
2. Automatically via `introspect_and_adapt()` which sets the version from server detection

**Applicable `rhosocial-activerecord` Version Range:**
>=1.0.0,<2.0.0 (requires core package with DialectNotAdaptedException support, v1.0.0.dev27+)

## Related Repositories/Packages

- **python-activerecord**: Core package with `DialectNotAdaptedException` and version guarding logic (PR #89)
- **python-activerecord-postgres**: PostgreSQL dialect version guarding changes (PR #37)

## Testing

- [ ] I have added new tests to cover my changes.
- [x] I have updated existing tests to reflect my changes.
- [x] All existing tests pass.
- [x] This change has been tested on MySQL backend.

**Test Plan:**
- Tests updated to use explicit version `(8, 0, 0)`
- CI will verify all tests pass across Python versions

## Checklist

- [x] My code follows the project's code style guidelines.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added a Changelog fragment.
- [x] I have verified that my changes do not introduce SQL injection vulnerabilities.
- [x] I have checked for potential performance regressions.

## Commits in this PR

1. `0732354` - feat(dialect): require version adaptation before using MySQL dialect