### PR TITLE
feat(mysql): add expression-level COLLATE support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,8 +52,8 @@ jobs:
 
       - name: Install activerecord and testsuite
         run: |
-          pip install rhosocial-activerecord==1.0.0.dev27
-          pip install rhosocial-activerecord-testsuite==1.0.0.dev14
+          pip install git+https://github.com/rhosocial/python-activerecord.git@release/v1.0.0.dev28#egg=rhosocial-activerecord
+          pip install git+https://github.com/rhosocial/python-activerecord-testsuite.git@release/v1.0.0.dev15#egg=rhosocial-activerecord-testsuite
 
       - name: Create and test database
         run: |
@@ -226,8 +226,8 @@ jobs:
 
       - name: Install activerecord and testsuite
         run: |
-          pip install rhosocial-activerecord==1.0.0.dev27
-          pip install rhosocial-activerecord-testsuite==1.0.0.dev14
+          pip install git+https://github.com/rhosocial/python-activerecord.git@release/v1.0.0.dev28#egg=rhosocial-activerecord
+          pip install git+https://github.com/rhosocial/python-activerecord-testsuite.git@release/v1.0.0.dev15#egg=rhosocial-activerecord-testsuite
 
       - name: Create and test database
         run: |

--- a/changelog.d/42.added.md
+++ b/changelog.d/42.added.md
@@ -1,0 +1,1 @@
+Added MySQL expression-level `COLLATE` support with version-aware collation validation.

--- a/src/rhosocial/activerecord/backend/impl/mysql/__init__.py
+++ b/src/rhosocial/activerecord/backend/impl/mysql/__init__.py
@@ -21,6 +21,7 @@ Architecture:
 from .backend import MySQLBackend
 from .async_backend import AsyncMySQLBackend
 from .config import MySQLConnectionConfig
+from .collation import MySQLCollation, MySQLCollationValidator
 from .dialect import MySQLDialect
 from .transaction import MySQLTransactionManager
 from .async_transaction import AsyncMySQLTransactionManager
@@ -130,6 +131,8 @@ __all__ = [
 
     # Dialect related
     'MySQLDialect',
+    'MySQLCollation',
+    'MySQLCollationValidator',
 
     # Transaction - Sync and Async
     'MySQLTransactionManager',

--- a/src/rhosocial/activerecord/backend/impl/mysql/adapters.py
+++ b/src/rhosocial/activerecord/backend/impl/mysql/adapters.py
@@ -23,7 +23,13 @@ class MySQLBlobAdapter(SQLTypeAdapter):
             return None
         return value
 
-    def from_database(self, value: Any, target_type: Type, options: Optional[Dict[str, Any]] = None) -> Optional[bytes]:
+    def from_database(
+        self,
+        value: Any,
+        target_type: Type,
+        options: Optional[Dict[str, Any]] = None,
+        **kwargs,
+    ) -> Optional[bytes]:
         if value is None:
             return None
         # MySQL connector usually returns bytes directly for BLOB types
@@ -46,7 +52,7 @@ class MySQLJSONAdapter(SQLTypeAdapter):
         return json.dumps(value, ensure_ascii=False)
 
     def from_database(
-        self, value: Any, target_type: Type, options: Optional[Dict[str, Any]] = None
+        self, value: Any, target_type: Type, options: Optional[Dict[str, Any]] = None, **kwargs
     ) -> Optional[Union[dict, list]]:
         if value is None:
             return None
@@ -70,7 +76,7 @@ class MySQLUUIDAdapter(SQLTypeAdapter):
         return str(value)
 
     def from_database(
-        self, value: Any, target_type: Type, options: Optional[Dict[str, Any]] = None
+        self, value: Any, target_type: Type, options: Optional[Dict[str, Any]] = None, **kwargs
     ) -> Optional[uuid.UUID]:
         if value is None:
             return None
@@ -92,7 +98,13 @@ class MySQLBooleanAdapter(SQLTypeAdapter):
             return None
         return 1 if value else 0
 
-    def from_database(self, value: Any, target_type: Type, options: Optional[Dict[str, Any]] = None) -> Optional[bool]:
+    def from_database(
+        self,
+        value: Any,
+        target_type: Type,
+        options: Optional[Dict[str, Any]] = None,
+        **kwargs,
+    ) -> Optional[bool]:
         if value is None:
             return None
         # MySQL returns int (0 or 1) for TINYINT(1)
@@ -119,7 +131,7 @@ class MySQLDecimalAdapter(SQLTypeAdapter):
         raise TypeError(f"Cannot convert {type(value).__name__} to {target_type.__name__}")
 
     def from_database(
-        self, value: Any, target_type: Type, options: Optional[Dict[str, Any]] = None
+        self, value: Any, target_type: Type, options: Optional[Dict[str, Any]] = None, **kwargs
     ) -> Optional[Decimal]:
         if value is None:
             return None
@@ -143,7 +155,7 @@ class MySQLDateAdapter(SQLTypeAdapter):
         return value.isoformat() # "YYYY-MM-DD"
 
     def from_database(
-        self, value: Any, target_type: Type, options: Optional[Dict[str, Any]] = None
+        self, value: Any, target_type: Type, options: Optional[Dict[str, Any]] = None, **kwargs
     ) -> Optional[datetime.date]:
         if value is None:
             return None
@@ -169,7 +181,7 @@ class MySQLTimeAdapter(SQLTypeAdapter):
         return value.isoformat(timespec='microseconds') # "HH:MM:SS.ffffff"
 
     def from_database(
-        self, value: Any, target_type: Type, options: Optional[Dict[str, Any]] = None
+        self, value: Any, target_type: Type, options: Optional[Dict[str, Any]] = None, **kwargs
     ) -> Optional[datetime.time]:
         if value is None:
             return None
@@ -217,7 +229,7 @@ class MySQLDatetimeAdapter(SQLTypeAdapter):
         return value
 
     def from_database(
-        self, value: Any, target_type: Type, options: Optional[Dict[str, Any]] = None
+        self, value: Any, target_type: Type, options: Optional[Dict[str, Any]] = None, **kwargs
     ) -> Optional[datetime.datetime]:
         if value is None:
             return None
@@ -334,7 +346,8 @@ class MySQLEnumAdapter(SQLTypeAdapter):
         )
 
     def from_database(
-        self, value: Any, target_type: Type[Enum], options: Optional[Dict[str, Any]] = None
+        self, value: Any, target_type: Type[Enum], options: Optional[Dict[str, Any]] = None,
+        **kwargs,
     ) -> Optional[Enum]:
         """
         Convert database value to Python Enum.
@@ -527,7 +540,8 @@ class MySQLSetAdapter(SQLTypeAdapter):
         self,
         value: Any,
         target_type: Type,
-        options: Optional[Dict[str, Any]] = None
+        options: Optional[Dict[str, Any]] = None,
+        **kwargs,
     ) -> Optional[Union[set, frozenset]]:
         """
         Convert MySQL SET string to Python set/frozenset.
@@ -708,7 +722,8 @@ class MySQLVectorAdapter(SQLTypeAdapter):
         self,
         value: Any,
         target_type: Type,
-        options: Optional[Dict[str, Any]] = None
+        options: Optional[Dict[str, Any]] = None,
+        **kwargs,
     ) -> Optional[List[float]]:
         """
         Convert MySQL VECTOR to Python list of floats.

--- a/src/rhosocial/activerecord/backend/impl/mysql/collation.py
+++ b/src/rhosocial/activerecord/backend/impl/mysql/collation.py
@@ -1,0 +1,346 @@
+# src/rhosocial/activerecord/backend/impl/mysql/collation.py
+"""
+MySQL collation names supported by the dialect whitelist.
+"""
+
+from enum import Enum
+from typing import Dict, Optional, Tuple
+
+
+class MySQLCollation(Enum):
+    """MySQL collations for expression-level COLLATE."""
+
+    # Built-in pseudo collation
+    BINARY = "binary"
+
+    # MySQL 5.7 and earlier character set collations
+    ARMSCII8_BIN = "armscii8_bin"
+    ARMSCII8_GENERAL_CI = "armscii8_general_ci"
+    ASCII_BIN = "ascii_bin"
+    ASCII_GENERAL_CI = "ascii_general_ci"
+    BIG5_BIN = "big5_bin"
+    BIG5_CHINESE_CI = "big5_chinese_ci"
+    CP1250_BIN = "cp1250_bin"
+    CP1250_CROATIAN_CI = "cp1250_croatian_ci"
+    CP1250_CZECH_CS = "cp1250_czech_cs"
+    CP1250_GENERAL_CI = "cp1250_general_ci"
+    CP1250_POLISH_CI = "cp1250_polish_ci"
+    CP1251_BIN = "cp1251_bin"
+    CP1251_BULGARIAN_CI = "cp1251_bulgarian_ci"
+    CP1251_GENERAL_CI = "cp1251_general_ci"
+    CP1251_GENERAL_CS = "cp1251_general_cs"
+    CP1251_UKRAINIAN_CI = "cp1251_ukrainian_ci"
+    CP1256_BIN = "cp1256_bin"
+    CP1256_GENERAL_CI = "cp1256_general_ci"
+    CP1257_BIN = "cp1257_bin"
+    CP1257_GENERAL_CI = "cp1257_general_ci"
+    CP1257_LITHUANIAN_CI = "cp1257_lithuanian_ci"
+    CP850_BIN = "cp850_bin"
+    CP850_GENERAL_CI = "cp850_general_ci"
+    CP852_BIN = "cp852_bin"
+    CP852_GENERAL_CI = "cp852_general_ci"
+    CP866_BIN = "cp866_bin"
+    CP866_GENERAL_CI = "cp866_general_ci"
+    CP932_BIN = "cp932_bin"
+    CP932_JAPANESE_CI = "cp932_japanese_ci"
+    DEC8_BIN = "dec8_bin"
+    DEC8_SWEDISH_CI = "dec8_swedish_ci"
+    EUCJPMS_BIN = "eucjpms_bin"
+    EUCJPMS_JAPANESE_CI = "eucjpms_japanese_ci"
+    EUCKR_BIN = "euckr_bin"
+    EUCKR_KOREAN_CI = "euckr_korean_ci"
+    GB2312_BIN = "gb2312_bin"
+    GB2312_CHINESE_CI = "gb2312_chinese_ci"
+    GBK_BIN = "gbk_bin"
+    GBK_CHINESE_CI = "gbk_chinese_ci"
+    GEOSTD8_BIN = "geostd8_bin"
+    GEOSTD8_GENERAL_CI = "geostd8_general_ci"
+    GREEK_BIN = "greek_bin"
+    GREEK_GENERAL_CI = "greek_general_ci"
+    HEBREW_BIN = "hebrew_bin"
+    HEBREW_GENERAL_CI = "hebrew_general_ci"
+    HP8_BIN = "hp8_bin"
+    HP8_ENGLISH_CI = "hp8_english_ci"
+    KEYBCS2_BIN = "keybcs2_bin"
+    KEYBCS2_GENERAL_CI = "keybcs2_general_ci"
+    KOI8R_BIN = "koi8r_bin"
+    KOI8R_GENERAL_CI = "koi8r_general_ci"
+    KOI8U_BIN = "koi8u_bin"
+    KOI8U_GENERAL_CI = "koi8u_general_ci"
+    LATIN1_BIN = "latin1_bin"
+    LATIN1_DANISH_CI = "latin1_danish_ci"
+    LATIN1_GENERAL_CI = "latin1_general_ci"
+    LATIN1_GENERAL_CS = "latin1_general_cs"
+    LATIN1_GERMAN1_CI = "latin1_german1_ci"
+    LATIN1_GERMAN2_CI = "latin1_german2_ci"
+    LATIN1_SPANISH_CI = "latin1_spanish_ci"
+    LATIN1_SWEDISH_CI = "latin1_swedish_ci"
+    LATIN2_BIN = "latin2_bin"
+    LATIN2_CROATIAN_CI = "latin2_croatian_ci"
+    LATIN2_CZECH_CS = "latin2_czech_cs"
+    LATIN2_GENERAL_CI = "latin2_general_ci"
+    LATIN2_HUNGARIAN_CI = "latin2_hungarian_ci"
+    LATIN5_BIN = "latin5_bin"
+    LATIN5_TURKISH_CI = "latin5_turkish_ci"
+    LATIN7_BIN = "latin7_bin"
+    LATIN7_ESTONIAN_CS = "latin7_estonian_cs"
+    LATIN7_GENERAL_CI = "latin7_general_ci"
+    LATIN7_GENERAL_CS = "latin7_general_cs"
+    MACCE_BIN = "macce_bin"
+    MACCE_GENERAL_CI = "macce_general_ci"
+    MACROMAN_BIN = "macroman_bin"
+    MACROMAN_GENERAL_CI = "macroman_general_ci"
+    SJIS_BIN = "sjis_bin"
+    SJIS_JAPANESE_CI = "sjis_japanese_ci"
+    SWE7_BIN = "swe7_bin"
+    SWE7_SWEDISH_CI = "swe7_swedish_ci"
+    TIS620_BIN = "tis620_bin"
+    TIS620_THAI_CI = "tis620_thai_ci"
+    UCS2_BIN = "ucs2_bin"
+    UCS2_CROATIAN_CI = "ucs2_croatian_ci"
+    UCS2_CZECH_CI = "ucs2_czech_ci"
+    UCS2_DANISH_CI = "ucs2_danish_ci"
+    UCS2_ESPERANTO_CI = "ucs2_esperanto_ci"
+    UCS2_ESTONIAN_CI = "ucs2_estonian_ci"
+    UCS2_GENERAL_CI = "ucs2_general_ci"
+    UCS2_GENERAL_MYSQL500_CI = "ucs2_general_mysql500_ci"
+    UCS2_GERMAN2_CI = "ucs2_german2_ci"
+    UCS2_HUNGARIAN_CI = "ucs2_hungarian_ci"
+    UCS2_ICELANDIC_CI = "ucs2_icelandic_ci"
+    UCS2_LATVIAN_CI = "ucs2_latvian_ci"
+    UCS2_LITHUANIAN_CI = "ucs2_lithuanian_ci"
+    UCS2_PERSIAN_CI = "ucs2_persian_ci"
+    UCS2_POLISH_CI = "ucs2_polish_ci"
+    UCS2_ROMAN_CI = "ucs2_roman_ci"
+    UCS2_ROMANIAN_CI = "ucs2_romanian_ci"
+    UCS2_SINHALA_CI = "ucs2_sinhala_ci"
+    UCS2_SLOVAK_CI = "ucs2_slovak_ci"
+    UCS2_SLOVENIAN_CI = "ucs2_slovenian_ci"
+    UCS2_SPANISH2_CI = "ucs2_spanish2_ci"
+    UCS2_SPANISH_CI = "ucs2_spanish_ci"
+    UCS2_SWEDISH_CI = "ucs2_swedish_ci"
+    UCS2_TURKISH_CI = "ucs2_turkish_ci"
+    UCS2_UNICODE_520_CI = "ucs2_unicode_520_ci"
+    UCS2_UNICODE_CI = "ucs2_unicode_ci"
+    UCS2_VIETNAMESE_CI = "ucs2_vietnamese_ci"
+    UJIS_BIN = "ujis_bin"
+    UJIS_JAPANESE_CI = "ujis_japanese_ci"
+    UTF16_BIN = "utf16_bin"
+    UTF16_CROATIAN_CI = "utf16_croatian_ci"
+    UTF16_CZECH_CI = "utf16_czech_ci"
+    UTF16_DANISH_CI = "utf16_danish_ci"
+    UTF16_ESPERANTO_CI = "utf16_esperanto_ci"
+    UTF16_ESTONIAN_CI = "utf16_estonian_ci"
+    UTF16_GENERAL_CI = "utf16_general_ci"
+    UTF16_GERMAN2_CI = "utf16_german2_ci"
+    UTF16_HUNGARIAN_CI = "utf16_hungarian_ci"
+    UTF16_ICELANDIC_CI = "utf16_icelandic_ci"
+    UTF16_LATVIAN_CI = "utf16_latvian_ci"
+    UTF16_LITHUANIAN_CI = "utf16_lithuanian_ci"
+    UTF16_PERSIAN_CI = "utf16_persian_ci"
+    UTF16_POLISH_CI = "utf16_polish_ci"
+    UTF16_ROMAN_CI = "utf16_roman_ci"
+    UTF16_ROMANIAN_CI = "utf16_romanian_ci"
+    UTF16_SINHALA_CI = "utf16_sinhala_ci"
+    UTF16_SLOVAK_CI = "utf16_slovak_ci"
+    UTF16_SLOVENIAN_CI = "utf16_slovenian_ci"
+    UTF16_SPANISH2_CI = "utf16_spanish2_ci"
+    UTF16_SPANISH_CI = "utf16_spanish_ci"
+    UTF16_SWEDISH_CI = "utf16_swedish_ci"
+    UTF16_TURKISH_CI = "utf16_turkish_ci"
+    UTF16_UNICODE_520_CI = "utf16_unicode_520_ci"
+    UTF16_UNICODE_CI = "utf16_unicode_ci"
+    UTF16_VIETNAMESE_CI = "utf16_vietnamese_ci"
+    UTF16LE_BIN = "utf16le_bin"
+    UTF16LE_GENERAL_CI = "utf16le_general_ci"
+    UTF32_BIN = "utf32_bin"
+    UTF32_CROATIAN_CI = "utf32_croatian_ci"
+    UTF32_CZECH_CI = "utf32_czech_ci"
+    UTF32_DANISH_CI = "utf32_danish_ci"
+    UTF32_ESPERANTO_CI = "utf32_esperanto_ci"
+    UTF32_ESTONIAN_CI = "utf32_estonian_ci"
+    UTF32_GENERAL_CI = "utf32_general_ci"
+    UTF32_GERMAN2_CI = "utf32_german2_ci"
+    UTF32_HUNGARIAN_CI = "utf32_hungarian_ci"
+    UTF32_ICELANDIC_CI = "utf32_icelandic_ci"
+    UTF32_LATVIAN_CI = "utf32_latvian_ci"
+    UTF32_LITHUANIAN_CI = "utf32_lithuanian_ci"
+    UTF32_PERSIAN_CI = "utf32_persian_ci"
+    UTF32_POLISH_CI = "utf32_polish_ci"
+    UTF32_ROMAN_CI = "utf32_roman_ci"
+    UTF32_ROMANIAN_CI = "utf32_romanian_ci"
+    UTF32_SINHALA_CI = "utf32_sinhala_ci"
+    UTF32_SLOVAK_CI = "utf32_slovak_ci"
+    UTF32_SLOVENIAN_CI = "utf32_slovenian_ci"
+    UTF32_SPANISH2_CI = "utf32_spanish2_ci"
+    UTF32_SPANISH_CI = "utf32_spanish_ci"
+    UTF32_SWEDISH_CI = "utf32_swedish_ci"
+    UTF32_TURKISH_CI = "utf32_turkish_ci"
+    UTF32_UNICODE_520_CI = "utf32_unicode_520_ci"
+    UTF32_UNICODE_CI = "utf32_unicode_ci"
+    UTF32_VIETNAMESE_CI = "utf32_vietnamese_ci"
+    UTF8MB3_BIN = "utf8mb3_bin"
+    UTF8MB3_CROATIAN_CI = "utf8mb3_croatian_ci"
+    UTF8MB3_CZECH_CI = "utf8mb3_czech_ci"
+    UTF8MB3_DANISH_CI = "utf8mb3_danish_ci"
+    UTF8MB3_ESPERANTO_CI = "utf8mb3_esperanto_ci"
+    UTF8MB3_ESTONIAN_CI = "utf8mb3_estonian_ci"
+    UTF8MB3_GENERAL_CI = "utf8mb3_general_ci"
+    UTF8MB3_GENERAL_MYSQL500_CI = "utf8mb3_general_mysql500_ci"
+    UTF8MB3_GERMAN2_CI = "utf8mb3_german2_ci"
+    UTF8MB3_HUNGARIAN_CI = "utf8mb3_hungarian_ci"
+    UTF8MB3_ICELANDIC_CI = "utf8mb3_icelandic_ci"
+    UTF8MB3_LATVIAN_CI = "utf8mb3_latvian_ci"
+    UTF8MB3_LITHUANIAN_CI = "utf8mb3_lithuanian_ci"
+    UTF8MB3_PERSIAN_CI = "utf8mb3_persian_ci"
+    UTF8MB3_POLISH_CI = "utf8mb3_polish_ci"
+    UTF8MB3_ROMAN_CI = "utf8mb3_roman_ci"
+    UTF8MB3_ROMANIAN_CI = "utf8mb3_romanian_ci"
+    UTF8MB3_SINHALA_CI = "utf8mb3_sinhala_ci"
+    UTF8MB3_SLOVAK_CI = "utf8mb3_slovak_ci"
+    UTF8MB3_SLOVENIAN_CI = "utf8mb3_slovenian_ci"
+    UTF8MB3_SPANISH2_CI = "utf8mb3_spanish2_ci"
+    UTF8MB3_SPANISH_CI = "utf8mb3_spanish_ci"
+    UTF8MB3_SWEDISH_CI = "utf8mb3_swedish_ci"
+    UTF8MB3_TURKISH_CI = "utf8mb3_turkish_ci"
+    UTF8MB3_UNICODE_520_CI = "utf8mb3_unicode_520_ci"
+    UTF8MB3_UNICODE_CI = "utf8mb3_unicode_ci"
+    UTF8MB3_VIETNAMESE_CI = "utf8mb3_vietnamese_ci"
+    UTF8MB4_BIN = "utf8mb4_bin"
+    UTF8MB4_CROATIAN_CI = "utf8mb4_croatian_ci"
+    UTF8MB4_CZECH_CI = "utf8mb4_czech_ci"
+    UTF8MB4_DANISH_CI = "utf8mb4_danish_ci"
+    UTF8MB4_ESPERANTO_CI = "utf8mb4_esperanto_ci"
+    UTF8MB4_ESTONIAN_CI = "utf8mb4_estonian_ci"
+    UTF8MB4_GENERAL_CI = "utf8mb4_general_ci"
+    UTF8MB4_GERMAN2_CI = "utf8mb4_german2_ci"
+    UTF8MB4_HUNGARIAN_CI = "utf8mb4_hungarian_ci"
+    UTF8MB4_ICELANDIC_CI = "utf8mb4_icelandic_ci"
+    UTF8MB4_LATVIAN_CI = "utf8mb4_latvian_ci"
+    UTF8MB4_LITHUANIAN_CI = "utf8mb4_lithuanian_ci"
+    UTF8MB4_PERSIAN_CI = "utf8mb4_persian_ci"
+    UTF8MB4_POLISH_CI = "utf8mb4_polish_ci"
+    UTF8MB4_ROMAN_CI = "utf8mb4_roman_ci"
+    UTF8MB4_ROMANIAN_CI = "utf8mb4_romanian_ci"
+    UTF8MB4_SINHALA_CI = "utf8mb4_sinhala_ci"
+    UTF8MB4_SLOVAK_CI = "utf8mb4_slovak_ci"
+    UTF8MB4_SLOVENIAN_CI = "utf8mb4_slovenian_ci"
+    UTF8MB4_SPANISH2_CI = "utf8mb4_spanish2_ci"
+    UTF8MB4_SPANISH_CI = "utf8mb4_spanish_ci"
+    UTF8MB4_SWEDISH_CI = "utf8mb4_swedish_ci"
+    UTF8MB4_TURKISH_CI = "utf8mb4_turkish_ci"
+    UTF8MB4_UNICODE_520_CI = "utf8mb4_unicode_520_ci"
+    UTF8MB4_UNICODE_CI = "utf8mb4_unicode_ci"
+    UTF8MB4_VIETNAMESE_CI = "utf8mb4_vietnamese_ci"
+
+    # MySQL 5.7+ GB18030 collations
+    GB18030_BIN = "gb18030_bin"
+    GB18030_CHINESE_CI = "gb18030_chinese_ci"
+    GB18030_UNICODE_520_CI = "gb18030_unicode_520_ci"
+
+    # MySQL 8.0 Unicode 9.0 utf8mb4_0900 collations
+    UTF8MB4_0900_AI_CI = "utf8mb4_0900_ai_ci"
+    UTF8MB4_0900_AS_CI = "utf8mb4_0900_as_ci"
+    UTF8MB4_0900_AS_CS = "utf8mb4_0900_as_cs"
+    UTF8MB4_0900_BIN = "utf8mb4_0900_bin"
+
+    # MySQL 8.0 language-specific utf8mb4_0900 collations
+    UTF8MB4_BG_0900_AI_CI = "utf8mb4_bg_0900_ai_ci"
+    UTF8MB4_BG_0900_AS_CS = "utf8mb4_bg_0900_as_cs"
+    UTF8MB4_BS_0900_AI_CI = "utf8mb4_bs_0900_ai_ci"
+    UTF8MB4_BS_0900_AS_CS = "utf8mb4_bs_0900_as_cs"
+    UTF8MB4_CS_0900_AI_CI = "utf8mb4_cs_0900_ai_ci"
+    UTF8MB4_CS_0900_AS_CS = "utf8mb4_cs_0900_as_cs"
+    UTF8MB4_DA_0900_AI_CI = "utf8mb4_da_0900_ai_ci"
+    UTF8MB4_DA_0900_AS_CS = "utf8mb4_da_0900_as_cs"
+    UTF8MB4_DE_PB_0900_AI_CI = "utf8mb4_de_pb_0900_ai_ci"
+    UTF8MB4_DE_PB_0900_AS_CS = "utf8mb4_de_pb_0900_as_cs"
+    UTF8MB4_EO_0900_AI_CI = "utf8mb4_eo_0900_ai_ci"
+    UTF8MB4_EO_0900_AS_CS = "utf8mb4_eo_0900_as_cs"
+    UTF8MB4_ES_0900_AI_CI = "utf8mb4_es_0900_ai_ci"
+    UTF8MB4_ES_0900_AS_CS = "utf8mb4_es_0900_as_cs"
+    UTF8MB4_ET_0900_AI_CI = "utf8mb4_et_0900_ai_ci"
+    UTF8MB4_ET_0900_AS_CS = "utf8mb4_et_0900_as_cs"
+    UTF8MB4_HR_0900_AI_CI = "utf8mb4_hr_0900_ai_ci"
+    UTF8MB4_HR_0900_AS_CS = "utf8mb4_hr_0900_as_cs"
+    UTF8MB4_HU_0900_AI_CI = "utf8mb4_hu_0900_ai_ci"
+    UTF8MB4_HU_0900_AS_CS = "utf8mb4_hu_0900_as_cs"
+    UTF8MB4_IS_0900_AI_CI = "utf8mb4_is_0900_ai_ci"
+    UTF8MB4_IS_0900_AS_CS = "utf8mb4_is_0900_as_cs"
+    UTF8MB4_JA_0900_AS_CS = "utf8mb4_ja_0900_as_cs"
+    UTF8MB4_JA_0900_AS_CS_KS = "utf8mb4_ja_0900_as_cs_ks"
+    UTF8MB4_LA_0900_AI_CI = "utf8mb4_la_0900_ai_ci"
+    UTF8MB4_LA_0900_AS_CS = "utf8mb4_la_0900_as_cs"
+    UTF8MB4_LT_0900_AI_CI = "utf8mb4_lt_0900_ai_ci"
+    UTF8MB4_LT_0900_AS_CS = "utf8mb4_lt_0900_as_cs"
+    UTF8MB4_LV_0900_AI_CI = "utf8mb4_lv_0900_ai_ci"
+    UTF8MB4_LV_0900_AS_CS = "utf8mb4_lv_0900_as_cs"
+    UTF8MB4_PL_0900_AI_CI = "utf8mb4_pl_0900_ai_ci"
+    UTF8MB4_PL_0900_AS_CS = "utf8mb4_pl_0900_as_cs"
+    UTF8MB4_RO_0900_AI_CI = "utf8mb4_ro_0900_ai_ci"
+    UTF8MB4_RO_0900_AS_CS = "utf8mb4_ro_0900_as_cs"
+    UTF8MB4_RU_0900_AI_CI = "utf8mb4_ru_0900_ai_ci"
+    UTF8MB4_RU_0900_AS_CS = "utf8mb4_ru_0900_as_cs"
+    UTF8MB4_SK_0900_AI_CI = "utf8mb4_sk_0900_ai_ci"
+    UTF8MB4_SK_0900_AS_CS = "utf8mb4_sk_0900_as_cs"
+    UTF8MB4_SL_0900_AI_CI = "utf8mb4_sl_0900_ai_ci"
+    UTF8MB4_SL_0900_AS_CS = "utf8mb4_sl_0900_as_cs"
+    UTF8MB4_SV_0900_AI_CI = "utf8mb4_sv_0900_ai_ci"
+    UTF8MB4_SV_0900_AS_CS = "utf8mb4_sv_0900_as_cs"
+    UTF8MB4_TR_0900_AI_CI = "utf8mb4_tr_0900_ai_ci"
+    UTF8MB4_TR_0900_AS_CS = "utf8mb4_tr_0900_as_cs"
+    UTF8MB4_VI_0900_AI_CI = "utf8mb4_vi_0900_ai_ci"
+    UTF8MB4_VI_0900_AS_CS = "utf8mb4_vi_0900_as_cs"
+    UTF8MB4_ZH_0900_AS_CS = "utf8mb4_zh_0900_as_cs"
+
+
+_COLLATION_VALUES = {collation.value for collation in MySQLCollation}
+_COLLATION_MIN_VERSIONS: Dict[str, Tuple[int, ...]] = {
+    collation.value: (8, 0, 0)
+    for collation in MySQLCollation
+    if "_0900_" in collation.value or collation.value.endswith("_0900_bin")
+}
+
+
+class MySQLCollationValidator:
+    """Validate MySQL collation names against version-gated known collations."""
+
+    @classmethod
+    def is_supported(
+        cls,
+        name: str,
+        version: Optional[Tuple[int, ...]] = None,
+    ) -> bool:
+        try:
+            cls.validate(name, version)
+        except ValueError:
+            return False
+        return True
+
+    @classmethod
+    def validate(
+        cls,
+        name: str,
+        version: Optional[Tuple[int, ...]] = None,
+    ) -> str:
+        normalized = name.lower()
+        if normalized not in _COLLATION_VALUES:
+            raise ValueError(f"Unsupported MySQL collation: {name!r}")
+
+        min_version = _COLLATION_MIN_VERSIONS.get(normalized)
+        if version is not None and min_version is not None and version < min_version:
+            raise ValueError(
+                f"MySQL collation requires MySQL {cls._format_version(min_version)}+: {name!r}"
+            )
+        return normalized
+
+    @staticmethod
+    def _format_version(version: Tuple[int, ...]) -> str:
+        return ".".join(str(part) for part in version[:2])
+
+
+def validate_mysql_collation_name(
+    name: str,
+    version: Optional[Tuple[int, ...]] = None,
+) -> str:
+    return MySQLCollationValidator.validate(name, version)

--- a/src/rhosocial/activerecord/backend/impl/mysql/dialect.py
+++ b/src/rhosocial/activerecord/backend/impl/mysql/dialect.py
@@ -96,7 +96,7 @@ from .collation import validate_mysql_collation_name
 from .show.dialect import MySQLShowDialectMixin
 
 if TYPE_CHECKING:
-    from rhosocial.activerecord.backend.expression.collation import CollationName
+    from rhosocial.activerecord.backend.expression.collation import CollateExpression
     from rhosocial.activerecord.backend.expression.statements import (
         CreateTableExpression, CreateViewExpression, DropViewExpression,
         ColumnDefinition, TableConstraint, IndexDefinition,
@@ -233,11 +233,12 @@ class MySQLDialect(
         """MySQL supports expression-level COLLATE."""
         return True
 
-    def validate_collation_name(self, collation: "CollationName") -> str:
+    def validate_collation_name(self, expr: "CollateExpression") -> str:
         """Validate MySQL collation names and return their SQL representation."""
-        if collation.schema is not None or collation.keyword is not None:
-            raise UnsupportedFeatureError(self.name, "schema-qualified or keyword COLLATE")
-        return validate_mysql_collation_name(collation.name, getattr(self, "version", None))
+        if expr.collation_options:
+            unsupported = ", ".join(sorted(expr.collation_options))
+            raise UnsupportedFeatureError(self.name, f"COLLATE options: {unsupported}")
+        return validate_mysql_collation_name(expr.collation_name, getattr(self, "version", None))
 
     @staticmethod
     def _escape_sql_string(value: str) -> str:

--- a/src/rhosocial/activerecord/backend/impl/mysql/dialect.py
+++ b/src/rhosocial/activerecord/backend/impl/mysql/dialect.py
@@ -10,6 +10,7 @@ from typing import Any, Dict, List, Optional, Tuple, TYPE_CHECKING, Union
 from rhosocial.activerecord.backend.dialect.base import SQLDialectBase
 from rhosocial.activerecord.backend.expression.bases import ToSQLProtocol
 from rhosocial.activerecord.backend.dialect.protocols import (
+    CollationSupport,
     CTESupport,
     FilterClauseSupport,
     WindowFunctionSupport,
@@ -38,6 +39,7 @@ from rhosocial.activerecord.backend.dialect.protocols import (
     SQLFunctionSupport,
 )
 from rhosocial.activerecord.backend.dialect.mixins import (
+    CollationMixin,
     CTEMixin,
     FilterClauseMixin,
     WindowFunctionMixin,
@@ -90,6 +92,7 @@ from .mixins import (
     MySQLLockingMixin,
     MySQLModifyColumnMixin,
 )
+from .collation import validate_mysql_collation_name
 from .show.dialect import MySQLShowDialectMixin
 
 if TYPE_CHECKING:
@@ -107,6 +110,7 @@ if TYPE_CHECKING:
 class MySQLDialect(
     SQLDialectBase,
     # Include mixins for features that MySQL supports (with version-dependent implementations)
+    CollationMixin,
     CTEMixin,
     FilterClauseMixin,
     WindowFunctionMixin,
@@ -148,6 +152,7 @@ class MySQLDialect(
     # Protocols for type checking
     # Note: MySQL-specific protocols extend generic protocols,
     # so only MySQL-specific protocols are needed for isinstance checks
+    CollationSupport,
     CTESupport,
     FilterClauseSupport,
     WindowFunctionSupport,
@@ -222,6 +227,16 @@ class MySQLDialect(
     def get_server_version(self) -> Tuple[int, int, int]:
         """Return the MySQL version this dialect is configured for."""
         return self.version
+
+    def supports_collate_expression(self) -> bool:
+        """MySQL supports expression-level COLLATE."""
+        return True
+
+    def format_collation_name(self, collation) -> str:
+        """Format MySQL collation names as validated bare tokens."""
+        if collation.schema is not None or collation.keyword is not None:
+            raise UnsupportedFeatureError(self.name, "schema-qualified or keyword COLLATE")
+        return validate_mysql_collation_name(collation.name, getattr(self, "version", None))
 
     @staticmethod
     def _escape_sql_string(value: str) -> str:

--- a/src/rhosocial/activerecord/backend/impl/mysql/dialect.py
+++ b/src/rhosocial/activerecord/backend/impl/mysql/dialect.py
@@ -96,6 +96,7 @@ from .collation import validate_mysql_collation_name
 from .show.dialect import MySQLShowDialectMixin
 
 if TYPE_CHECKING:
+    from rhosocial.activerecord.backend.expression.collation import CollationName
     from rhosocial.activerecord.backend.expression.statements import (
         CreateTableExpression, CreateViewExpression, DropViewExpression,
         ColumnDefinition, TableConstraint, IndexDefinition,
@@ -232,7 +233,7 @@ class MySQLDialect(
         """MySQL supports expression-level COLLATE."""
         return True
 
-    def validate_collation_name(self, collation) -> str:
+    def validate_collation_name(self, collation: "CollationName") -> str:
         """Validate MySQL collation names and return their SQL representation."""
         if collation.schema is not None or collation.keyword is not None:
             raise UnsupportedFeatureError(self.name, "schema-qualified or keyword COLLATE")

--- a/src/rhosocial/activerecord/backend/impl/mysql/dialect.py
+++ b/src/rhosocial/activerecord/backend/impl/mysql/dialect.py
@@ -232,8 +232,8 @@ class MySQLDialect(
         """MySQL supports expression-level COLLATE."""
         return True
 
-    def format_collation_name(self, collation) -> str:
-        """Format MySQL collation names as validated bare tokens."""
+    def validate_collation_name(self, collation) -> str:
+        """Validate MySQL collation names and return their SQL representation."""
         if collation.schema is not None or collation.keyword is not None:
             raise UnsupportedFeatureError(self.name, "schema-qualified or keyword COLLATE")
         return validate_mysql_collation_name(collation.name, getattr(self, "version", None))

--- a/tests/providers/basic.py
+++ b/tests/providers/basic.py
@@ -30,7 +30,8 @@ from rhosocial.activerecord.testsuite.feature.basic.fixtures.models import (
     TypeAdapterTest as TypeAdapterTestBase, YesOrNoBooleanAdapter,
     PydanticValidatedModel as PydanticValidatedModelBase,
     MappedUser as MappedUserBase, MappedPost as MappedPostBase, MappedComment as MappedCommentBase,
-    ColumnMappingModel as ColumnMappingModelBase, MixedAnnotationModel as MixedAnnotationModelBase
+    ColumnMappingModel as ColumnMappingModelBase, MixedAnnotationModel as MixedAnnotationModelBase,
+    BulkUser as BulkUserBase
 )
 # Import async base models
 from rhosocial.activerecord.testsuite.feature.basic.fixtures.models import (
@@ -40,16 +41,17 @@ from rhosocial.activerecord.testsuite.feature.basic.fixtures.models import (
     AsyncPydanticValidatedModel as AsyncPydanticValidatedModelBase,
     AsyncMappedUser as AsyncMappedUserBase, AsyncMappedPost as AsyncMappedPostBase,
     AsyncMappedComment as AsyncMappedCommentBase,
-    AsyncColumnMappingModel as AsyncColumnMappingModelBase, AsyncMixedAnnotationModel as AsyncMixedAnnotationModelBase
+    AsyncColumnMappingModel as AsyncColumnMappingModelBase, AsyncMixedAnnotationModel as AsyncMixedAnnotationModelBase,
+    AsyncBulkUser as AsyncBulkUserBase
 )
 
 # Conditionally import Python 3.10+ models
 User310 = TypeCase310 = ValidatedFieldUser310 = TypeTestModel310 = ValidatedUser310 = None
 TypeAdapterTest310 = PydanticValidatedModel310 = MappedUser310 = MappedPost310 = MappedComment310 = None
-ColumnMappingModel310 = MixedAnnotationModel310 = None
+ColumnMappingModel310 = MixedAnnotationModel310 = BulkUser310 = None
 AsyncUser310 = AsyncTypeCase310 = AsyncValidatedFieldUser310 = AsyncTypeTestModel310 = None
 AsyncValidatedUser310 = AsyncTypeAdapterTest310 = AsyncPydanticValidatedModel310 = AsyncMappedUser310 = AsyncMappedPost310 = None
-AsyncMappedComment310 = AsyncColumnMappingModel310 = AsyncMixedAnnotationModel310 = None
+AsyncMappedComment310 = AsyncColumnMappingModel310 = AsyncMixedAnnotationModel310 = AsyncBulkUser310 = None
 
 if sys.version_info >= (3, 10):
     try:
@@ -58,7 +60,8 @@ if sys.version_info >= (3, 10):
             TypeTestModel as TypeTestModel310, ValidatedUser as ValidatedUser310,
             TypeAdapterTest as TypeAdapterTest310, PydanticValidatedModel as PydanticValidatedModel310,
             MappedUser as MappedUser310, MappedPost as MappedPost310, MappedComment as MappedComment310,
-            ColumnMappingModel as ColumnMappingModel310, MixedAnnotationModel as MixedAnnotationModel310
+            ColumnMappingModel as ColumnMappingModel310, MixedAnnotationModel as MixedAnnotationModel310,
+            BulkUser as BulkUser310
         )
         from rhosocial.activerecord.testsuite.feature.basic.fixtures.models_py310 import (
             AsyncUser as AsyncUser310, AsyncTypeCase as AsyncTypeCase310,
@@ -67,7 +70,8 @@ if sys.version_info >= (3, 10):
             AsyncPydanticValidatedModel as AsyncPydanticValidatedModel310,
             AsyncMappedUser as AsyncMappedUser310, AsyncMappedPost as AsyncMappedPost310,
             AsyncMappedComment as AsyncMappedComment310,
-            AsyncColumnMappingModel as AsyncColumnMappingModel310, AsyncMixedAnnotationModel as AsyncMixedAnnotationModel310
+            AsyncColumnMappingModel as AsyncColumnMappingModel310, AsyncMixedAnnotationModel as AsyncMixedAnnotationModel310,
+            AsyncBulkUser as AsyncBulkUser310
         )
     except ImportError as e:
         logger.warning(f"Failed to import Python 3.10+ fixtures: {e}")
@@ -75,10 +79,10 @@ if sys.version_info >= (3, 10):
 # Conditionally import Python 3.11+ models
 User311 = TypeCase311 = ValidatedFieldUser311 = TypeTestModel311 = ValidatedUser311 = None
 TypeAdapterTest311 = PydanticValidatedModel311 = MappedUser311 = MappedPost311 = MappedComment311 = None
-ColumnMappingModel311 = MixedAnnotationModel311 = None
+ColumnMappingModel311 = MixedAnnotationModel311 = BulkUser311 = None
 AsyncUser311 = AsyncTypeCase311 = AsyncValidatedFieldUser311 = AsyncTypeTestModel311 = None
 AsyncValidatedUser311 = AsyncTypeAdapterTest311 = AsyncPydanticValidatedModel311 = AsyncMappedUser311 = AsyncMappedPost311 = None
-AsyncMappedComment311 = AsyncColumnMappingModel311 = AsyncMixedAnnotationModel311 = None
+AsyncMappedComment311 = AsyncColumnMappingModel311 = AsyncMixedAnnotationModel311 = AsyncBulkUser311 = None
 
 if sys.version_info >= (3, 11):
     try:
@@ -87,7 +91,8 @@ if sys.version_info >= (3, 11):
             TypeTestModel as TypeTestModel311, ValidatedUser as ValidatedUser311,
             TypeAdapterTest as TypeAdapterTest311, PydanticValidatedModel as PydanticValidatedModel311,
             MappedUser as MappedUser311, MappedPost as MappedPost311, MappedComment as MappedComment311,
-            ColumnMappingModel as ColumnMappingModel311, MixedAnnotationModel as MixedAnnotationModel311
+            ColumnMappingModel as ColumnMappingModel311, MixedAnnotationModel as MixedAnnotationModel311,
+            BulkUser as BulkUser311
         )
         from rhosocial.activerecord.testsuite.feature.basic.fixtures.models_py311 import (
             AsyncUser as AsyncUser311, AsyncTypeCase as AsyncTypeCase311,
@@ -96,7 +101,8 @@ if sys.version_info >= (3, 11):
             AsyncPydanticValidatedModel as AsyncPydanticValidatedModel311,
             AsyncMappedUser as AsyncMappedUser311, AsyncMappedPost as AsyncMappedPost311,
             AsyncMappedComment as AsyncMappedComment311,
-            AsyncColumnMappingModel as AsyncColumnMappingModel311, AsyncMixedAnnotationModel as AsyncMixedAnnotationModel311
+            AsyncColumnMappingModel as AsyncColumnMappingModel311, AsyncMixedAnnotationModel as AsyncMixedAnnotationModel311,
+            AsyncBulkUser as AsyncBulkUser311
         )
     except ImportError as e:
         logger.warning(f"Failed to import Python 3.11+ fixtures: {e}")
@@ -104,10 +110,10 @@ if sys.version_info >= (3, 11):
 # Conditionally import Python 3.12+ models
 User312 = TypeCase312 = ValidatedFieldUser312 = TypeTestModel312 = ValidatedUser312 = None
 TypeAdapterTest312 = PydanticValidatedModel312 = MappedUser312 = MappedPost312 = MappedComment312 = None
-ColumnMappingModel312 = MixedAnnotationModel312 = None
+ColumnMappingModel312 = MixedAnnotationModel312 = BulkUser312 = None
 AsyncUser312 = AsyncTypeCase312 = AsyncValidatedFieldUser312 = AsyncTypeTestModel312 = None
 AsyncValidatedUser312 = AsyncTypeAdapterTest312 = AsyncPydanticValidatedModel312 = AsyncMappedUser312 = AsyncMappedPost312 = None
-AsyncMappedComment312 = AsyncColumnMappingModel312 = AsyncMixedAnnotationModel312 = None
+AsyncMappedComment312 = AsyncColumnMappingModel312 = AsyncMixedAnnotationModel312 = AsyncBulkUser312 = None
 
 if sys.version_info >= (3, 12):
     try:
@@ -116,7 +122,8 @@ if sys.version_info >= (3, 12):
             TypeTestModel as TypeTestModel312, ValidatedUser as ValidatedUser312,
             TypeAdapterTest as TypeAdapterTest312, PydanticValidatedModel as PydanticValidatedModel312,
             MappedUser as MappedUser312, MappedPost as MappedPost312, MappedComment as MappedComment312,
-            ColumnMappingModel as ColumnMappingModel312, MixedAnnotationModel as MixedAnnotationModel312
+            ColumnMappingModel as ColumnMappingModel312, MixedAnnotationModel as MixedAnnotationModel312,
+            BulkUser as BulkUser312
         )
         from rhosocial.activerecord.testsuite.feature.basic.fixtures.models_py312 import (
             AsyncUser as AsyncUser312, AsyncTypeCase as AsyncTypeCase312,
@@ -125,7 +132,8 @@ if sys.version_info >= (3, 12):
             AsyncPydanticValidatedModel as AsyncPydanticValidatedModel312,
             AsyncMappedUser as AsyncMappedUser312, AsyncMappedPost as AsyncMappedPost312,
             AsyncMappedComment as AsyncMappedComment312,
-            AsyncColumnMappingModel as AsyncColumnMappingModel312, AsyncMixedAnnotationModel as AsyncMixedAnnotationModel312
+            AsyncColumnMappingModel as AsyncColumnMappingModel312, AsyncMixedAnnotationModel as AsyncMixedAnnotationModel312,
+            AsyncBulkUser as AsyncBulkUser312
         )
     except ImportError as e:
         logger.warning(f"Failed to import Python 3.12+ fixtures: {e}")
@@ -153,6 +161,7 @@ MappedPost = _select_model_class(MappedPostBase, MappedPost312, MappedPost311, M
 MappedComment = _select_model_class(MappedCommentBase, MappedComment312, MappedComment311, MappedComment310, "MappedComment")
 ColumnMappingModel = _select_model_class(ColumnMappingModelBase, ColumnMappingModel312, ColumnMappingModel311, ColumnMappingModel310, "ColumnMappingModel")
 MixedAnnotationModel = _select_model_class(MixedAnnotationModelBase, MixedAnnotationModel312, MixedAnnotationModel311, MixedAnnotationModel310, "MixedAnnotationModel")
+BulkUser = _select_model_class(BulkUserBase, BulkUser312, BulkUser311, BulkUser310, "BulkUser")
 
 # Select async models
 AsyncUser = _select_model_class(AsyncUserBase, AsyncUser312, AsyncUser311, AsyncUser310, "AsyncUser")
@@ -167,6 +176,7 @@ AsyncMappedPost = _select_model_class(AsyncMappedPostBase, AsyncMappedPost312, A
 AsyncMappedComment = _select_model_class(AsyncMappedCommentBase, AsyncMappedComment312, AsyncMappedComment311, AsyncMappedComment310, "AsyncMappedComment")
 AsyncColumnMappingModel = _select_model_class(AsyncColumnMappingModelBase, AsyncColumnMappingModel312, AsyncColumnMappingModel311, AsyncColumnMappingModel310, "AsyncColumnMappingModel")
 AsyncMixedAnnotationModel = _select_model_class(AsyncMixedAnnotationModelBase, AsyncMixedAnnotationModel312, AsyncMixedAnnotationModel311, AsyncMixedAnnotationModel310, "AsyncMixedAnnotationModel")
+AsyncBulkUser = _select_model_class(AsyncBulkUserBase, AsyncBulkUser312, AsyncBulkUser311, AsyncBulkUser310, "AsyncBulkUser")
 
 from rhosocial.activerecord.testsuite.feature.basic.interfaces import IBasicProvider
 from rhosocial.activerecord.testsuite.core.protocols import WorkerTestProtocol
@@ -405,6 +415,14 @@ class BasicProvider(IBasicProvider, WorkerTestProtocol):
             scenario_name = self.get_test_scenarios()[0] if self.get_test_scenarios() else "default"
         return await self._setup_async_model(AsyncTypeAdapterTest, scenario_name, "type_adapter_tests")
 
+    def setup_bulk_user_model(self, scenario_name: str) -> Type[ActiveRecord]:
+        """Sets up the database for the `BulkUser` model tests."""
+        return self._setup_model(BulkUser, scenario_name, "bulk_users")
+
+    async def setup_async_bulk_user_model(self, scenario_name: str) -> Type[ActiveRecord]:
+        """Sets up the database for the `AsyncBulkUser` model tests."""
+        return await self._setup_async_model(AsyncBulkUser, scenario_name, "bulk_users")
+
     def get_yes_no_adapter(self) -> 'BaseSQLTypeAdapter':
         """Returns an instance of the YesOrNoBooleanAdapter."""
         return YesOrNoBooleanAdapter()
@@ -424,7 +442,7 @@ class BasicProvider(IBasicProvider, WorkerTestProtocol):
         tables_to_drop = [
             'users', 'type_cases', 'type_tests', 'validated_field_users',
             'validated_users', 'pydantic_validated_models', 'type_adapter_tests',
-            'posts', 'comments', 'column_mapping_items', 'mixed_annotation_items'
+            'bulk_users', 'posts', 'comments', 'column_mapping_items', 'mixed_annotation_items'
         ]
         for backend_instance in self._active_backends:
             try:
@@ -454,7 +472,7 @@ class BasicProvider(IBasicProvider, WorkerTestProtocol):
         tables_to_drop = [
             'users', 'type_cases', 'type_tests', 'validated_field_users',
             'validated_users', 'pydantic_validated_models', 'type_adapter_tests',
-            'posts', 'comments', 'column_mapping_items', 'mixed_annotation_items'
+            'bulk_users', 'posts', 'comments', 'column_mapping_items', 'mixed_annotation_items'
         ]
         for backend_instance in self._active_async_backends:
             try:

--- a/tests/rhosocial/activerecord_mysql_test/feature/backend/test_mysql_protocol_conformance.py
+++ b/tests/rhosocial/activerecord_mysql_test/feature/backend/test_mysql_protocol_conformance.py
@@ -70,6 +70,7 @@ def get_own_protocol_methods(proto: type) -> set:
 
 
 MYSQL_PROTOCOLS = [
+    dialect_protocols.CollationSupport,
     dialect_protocols.CTESupport,
     dialect_protocols.FilterClauseSupport,
     dialect_protocols.WindowFunctionSupport,

--- a/tests/rhosocial/activerecord_mysql_test/feature/query/mysql/test_collation_expression.py
+++ b/tests/rhosocial/activerecord_mysql_test/feature/query/mysql/test_collation_expression.py
@@ -1,0 +1,123 @@
+# tests/rhosocial/activerecord_mysql_test/feature/query/mysql/test_collation_expression.py
+"""
+Tests for expression-level COLLATE support on MySQL.
+"""
+
+import pytest
+
+from rhosocial.activerecord.backend.expression import CollationName, Column, Literal
+from rhosocial.activerecord.backend.impl.mysql import (
+    MySQLCollation,
+    MySQLCollationValidator,
+    MySQLDialect,
+)
+
+
+@pytest.fixture
+def dialect():
+    return MySQLDialect(version=(8, 0, 0))
+
+
+@pytest.fixture
+def collation_table(mysql_backend):
+    mysql_backend.execute("DROP TABLE IF EXISTS test_collation_expression")
+    mysql_backend.execute("""
+        CREATE TABLE test_collation_expression (
+            id INT AUTO_INCREMENT PRIMARY KEY,
+            name VARCHAR(191) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL
+        ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+    """)
+    mysql_backend.execute("""
+        INSERT INTO test_collation_expression (name)
+        VALUES ('Alice'), ('alice'), ('Bob')
+    """)
+    yield "test_collation_expression"
+    mysql_backend.execute("DROP TABLE IF EXISTS test_collation_expression")
+
+
+class TestMySQLCollationValidator:
+    def test_supports_known_legacy_collation(self):
+        assert MySQLCollationValidator.is_supported("utf8mb4_unicode_ci", (5, 7, 0))
+
+    def test_rejects_mysql_8_collation_on_older_version(self):
+        assert not MySQLCollationValidator.is_supported("utf8mb4_0900_ai_ci", (5, 7, 0))
+        assert MySQLCollationValidator.is_supported("utf8mb4_0900_ai_ci", (8, 0, 0))
+
+    def test_validate_normalizes_case(self):
+        assert MySQLCollationValidator.validate("UTF8MB4_BIN", (5, 7, 0)) == "utf8mb4_bin"
+
+    def test_validate_rejects_unknown_collation(self):
+        with pytest.raises(ValueError, match="Unsupported MySQL collation"):
+            MySQLCollationValidator.validate("unknown_ci", (8, 0, 0))
+
+    def test_enum_contains_representative_collations(self):
+        values = {collation.value for collation in MySQLCollation}
+
+        assert "binary" in values
+        assert "latin1_swedish_ci" in values
+        assert "utf8mb4_unicode_ci" in values
+        assert "utf8mb4_0900_ai_ci" in values
+        assert "utf8mb4_ja_0900_as_cs" in values
+
+
+class TestMySQLCollationExpression:
+    def test_column_collate_generates_sql(self, dialect):
+        expr = Column(dialect, "name", table="users").collate(MySQLCollation.UTF8MB4_BIN)
+
+        sql, params = expr.to_sql()
+
+        assert sql == "`users`.`name` COLLATE utf8mb4_bin"
+        assert params == ()
+
+    def test_literal_collate_preserves_parameter_binding(self, dialect):
+        expr = Literal(dialect, "Alice").collate(MySQLCollation.UTF8MB4_0900_AI_CI)
+
+        sql, params = expr.to_sql()
+
+        assert sql == "%s COLLATE utf8mb4_0900_ai_ci"
+        assert params == ("Alice",)
+
+    def test_rejects_schema_qualified_collation(self, dialect):
+        expr = Column(dialect, "name").collate(CollationName("utf8mb4_bin", schema="public"))
+
+        with pytest.raises(Exception, match="schema-qualified or keyword COLLATE"):
+            expr.to_sql()
+
+    def test_rejects_unsupported_collation(self, dialect):
+        expr = Column(dialect, "name").collate("unknown_ci")
+
+        with pytest.raises(ValueError, match="Unsupported MySQL collation"):
+            expr.to_sql()
+
+    def test_rejects_mysql_8_collation_on_older_version(self):
+        dialect = MySQLDialect(version=(5, 7, 0))
+        expr = Column(dialect, "name").collate(MySQLCollation.UTF8MB4_0900_AI_CI)
+
+        with pytest.raises(ValueError, match="requires MySQL 8.0"):
+            expr.to_sql()
+
+    def test_collate_executes_case_sensitive_match(self, mysql_backend, collation_table):
+        expr = Column(mysql_backend.dialect, "name", table=collation_table).collate(
+            MySQLCollation.UTF8MB4_BIN
+        )
+        sql, params = expr.to_sql()
+
+        rows = mysql_backend.fetch_all(
+            f"SELECT name FROM `{collation_table}` WHERE {sql} = %s ORDER BY id",
+            (*params, "Alice"),
+        )
+
+        assert [row["name"] for row in rows] == ["Alice"]
+
+    def test_collate_executes_case_insensitive_match(self, mysql_backend, collation_table):
+        expr = Column(mysql_backend.dialect, "name", table=collation_table).collate(
+            MySQLCollation.UTF8MB4_UNICODE_CI
+        )
+        sql, params = expr.to_sql()
+
+        rows = mysql_backend.fetch_all(
+            f"SELECT name FROM `{collation_table}` WHERE {sql} = %s ORDER BY id",
+            (*params, "Alice"),
+        )
+
+        assert [row["name"] for row in rows] == ["Alice", "alice"]

--- a/tests/rhosocial/activerecord_mysql_test/feature/query/mysql/test_collation_expression.py
+++ b/tests/rhosocial/activerecord_mysql_test/feature/query/mysql/test_collation_expression.py
@@ -5,7 +5,7 @@ Tests for expression-level COLLATE support on MySQL.
 
 import pytest
 
-from rhosocial.activerecord.backend.expression import CollationName, Column, Literal
+from rhosocial.activerecord.backend.expression import Column, Literal
 from rhosocial.activerecord.backend.impl.mysql import (
     MySQLCollation,
     MySQLCollationValidator,
@@ -78,9 +78,9 @@ class TestMySQLCollationExpression:
         assert params == ("Alice",)
 
     def test_rejects_schema_qualified_collation(self, dialect):
-        expr = Column(dialect, "name").collate(CollationName("utf8mb4_bin", schema="public"))
+        expr = Column(dialect, "name").collate("utf8mb4_bin", schema="public")
 
-        with pytest.raises(Exception, match="schema-qualified or keyword COLLATE"):
+        with pytest.raises(Exception, match="COLLATE options: schema"):
             expr.to_sql()
 
     def test_rejects_unsupported_collation(self, dialect):


### PR DESCRIPTION
## Description

Adds MySQL expression-level `COLLATE` support for SQL value expressions.

This introduces a MySQL collation enum and validator, integrates dialect-level collation validation with the core `CollateExpression` hook, and adds MySQL-specific tests for valid collations, unsupported options, and version-gated collation names.

Adds # (issue)

## Type of change

- [x] `feat`: A new feature
- [ ] `docs`: Documentation only changes (if related to the new feature)
- [ ] `perf`: A code change that improves performance (if part of the feature)
- [x] `test`: Adding missing tests or correcting existing tests (for the new feature)
- [ ] `chore`: Changes to the build process or auxiliary tools and libraries suchs as documentation generation (if related to the feature)
- [ ] `ci`: Changes to our CI configuration files and scripts (if related to the feature)
- [ ] `build`: Changes that affect the build system or external dependencies (if related to the feature)
- [ ] `revert`: Reverts a previous commit

## Breaking Change

- [ ] Yes
- [x] No

**Applicable `rhosocial-activerecord` Version Range:**
Compatible with the core version that provides expression-level `CollateExpression` dialect hooks.

## Related Repositories/Packages

This PR depends on the corresponding core `python-activerecord` COLLATE support, merged in PR #97. Related backend plugin PRs should use the same `CollateExpression`-based validation contract.

## Testing

- [x] I have added new tests to cover my changes.
- [x] I have updated existing tests to reflect my changes.
- [ ] All existing tests pass.
- [x] This change has been tested on MySQL.

**Test Plan:**

- `source .venv3.8/bin/activate && pytest tests/rhosocial/activerecord_mysql_test/feature/query/mysql/test_collation_expression.py && deactivate`
- Result from targeted COLLATE validation during development: `12 passed`
- Local full test suite was skipped during PR preparation by request.

## Checklist

- [x] My code follows the project's [code style guidelines](./.gemini/code_style.md).
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation (Docstrings, `README.md`, etc.).
- [ ] My changes generate no new warnings.
- [ ] I have added a [Changelog fragment](./.gemini/version_control.md#5-changelog-management-with-towncrier) (`changelog.d/<issue_number>.<type>.md`).
- [x] I have verified that my changes do not introduce SQL injection vulnerabilities.
- [x] I have checked for potential performance regressions.

## Additional Notes

MySQL collation availability is version-sensitive. The validator rejects known MySQL 8.0-only collations when the dialect version is older than their minimum supported server version.
