### PR TITLE
feat(mysql): add datetime interval expressions with EXPLAIN examples

### DIFF
--- a/changelog.d/43.added.md
+++ b/changelog.d/43.added.md
@@ -1,0 +1,1 @@
+Added MySQL dialect support for datetime interval expressions (`EXTRACT`, `DATE_ADD`, `DATE_SUB`, `TIMESTAMPDIFF`) with EXPLAIN-backed index usage verification tests.

--- a/src/rhosocial/activerecord/backend/impl/mysql/dialect.py
+++ b/src/rhosocial/activerecord/backend/impl/mysql/dialect.py
@@ -237,6 +237,50 @@ class MySQLDialect(
         """Return the MySQL version this dialect is configured for."""
         return self.version
 
+    def format_date_trunc_expression(self, expr: "Any") -> Tuple[str, Tuple]:
+        source_sql, source_params = expr.source.to_sql()
+        field = expr.field.value.upper()
+        sql = f"CAST(DATE_FORMAT({source_sql}, %s) AS DATETIME)"
+        formats = {
+            "YEAR": "%Y-01-01 00:00:00",
+            "MONTH": "%Y-%m-01 00:00:00",
+            "DAY": "%Y-%m-%d 00:00:00",
+            "HOUR": "%Y-%m-%d %H:00:00",
+            "MINUTE": "%Y-%m-%d %H:%i:00",
+            "SECOND": "%Y-%m-%d %H:%i:%s",
+        }
+        if field not in formats:
+            raise UnsupportedFeatureError(self.name, f"date_trunc({expr.field.value})")
+        return self._apply_value_expression_modifiers(
+            sql, source_params + (formats[field],), expr
+        )
+
+    def format_interval_expression(self, expr: "Any") -> Tuple[str, Tuple]:
+        sql = f"INTERVAL %s {expr.unit.value.upper()}"
+        return self._apply_value_expression_modifiers(sql, (expr.value,), expr)
+
+    def format_datetime_add_expression(self, expr: "Any") -> Tuple[str, Tuple]:
+        source_sql, source_params = expr.source.to_sql()
+        interval_sql, interval_params = expr.interval.to_sql()
+        sql = f"DATE_ADD({source_sql}, {interval_sql})"
+        return self._apply_value_expression_modifiers(
+            sql, source_params + interval_params, expr
+        )
+
+    def format_datetime_subtract_expression(self, expr: "Any") -> Tuple[str, Tuple]:
+        source_sql, source_params = expr.source.to_sql()
+        interval_sql, interval_params = expr.interval.to_sql()
+        sql = f"DATE_SUB({source_sql}, {interval_sql})"
+        return self._apply_value_expression_modifiers(
+            sql, source_params + interval_params, expr
+        )
+
+    def format_datetime_diff_expression(self, expr: "Any") -> Tuple[str, Tuple]:
+        start_sql, start_params = expr.start.to_sql()
+        end_sql, end_params = expr.end.to_sql()
+        sql = f"TIMESTAMPDIFF({expr.unit.value.upper()}, {start_sql}, {end_sql})"
+        return self._apply_value_expression_modifiers(sql, start_params + end_params, expr)
+
     def supports_collate_expression(self) -> bool:
         """MySQL supports expression-level COLLATE."""
         return True

--- a/tests/rhosocial/activerecord_mysql_test/feature/backend/test_mysql_datetime_interval_explain_examples.py
+++ b/tests/rhosocial/activerecord_mysql_test/feature/backend/test_mysql_datetime_interval_explain_examples.py
@@ -1,0 +1,272 @@
+# tests/rhosocial/activerecord_mysql_test/feature/backend/test_mysql_datetime_interval_explain_examples.py
+"""MySQL EXPLAIN examples for datetime interval expressions and indexes."""
+
+import pytest
+import pytest_asyncio
+
+from rhosocial.activerecord.backend.expression import (
+    Column,
+    ComparisonPredicate,
+    Literal,
+    LogicalPredicate,
+    QueryExpression,
+    TableExpression,
+)
+from rhosocial.activerecord.backend.expression.functions import (
+    date_add,
+    date_diff,
+    date_sub,
+    extract,
+)
+from rhosocial.activerecord.backend.expression.query_parts import OrderByClause
+from rhosocial.activerecord.backend.impl.mysql import MySQLExplainResult
+from rhosocial.activerecord.backend.options import ExecutionOptions
+from rhosocial.activerecord.backend.schema import StatementType
+
+
+_SETUP_SQL = """
+    DROP TABLE IF EXISTS explain_temporal_events;
+
+    CREATE TABLE explain_temporal_events (
+        id INT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+        category VARCHAR(32) NOT NULL,
+        created_at DATETIME NOT NULL,
+        started_at DATETIME NOT NULL,
+        ended_at DATETIME NOT NULL,
+        INDEX idx_temporal_created_at (created_at),
+        INDEX idx_temporal_started_ended (started_at, ended_at),
+        INDEX idx_temporal_category_created (category, created_at)
+    ) ENGINE=InnoDB;
+
+    INSERT INTO explain_temporal_events (category, created_at, started_at, ended_at)
+    WITH RECURSIVE seq AS (
+        SELECT 0 AS n
+        UNION ALL
+        SELECT n + 1 FROM seq WHERE n < 119
+    )
+    SELECT
+        CASE
+            WHEN n IN (55, 58, 62) THEN 'deploy'
+            WHEN MOD(n, 3) = 0 THEN 'billing'
+            WHEN MOD(n, 3) = 1 THEN 'report'
+            ELSE 'maintenance'
+        END,
+        TIMESTAMP('2026-01-01 00:00:00') + INTERVAL n DAY,
+        TIMESTAMP('2026-01-01 00:00:00') + INTERVAL n DAY + INTERVAL 10 MINUTE,
+        TIMESTAMP('2026-01-01 00:00:00') + INTERVAL n DAY + INTERVAL 40 MINUTE
+    FROM seq;
+"""
+
+_CLEANUP_SQL = "DROP TABLE IF EXISTS explain_temporal_events;"
+_DQL_OPTIONS = ExecutionOptions(stmt_type=StatementType.DQL)
+_INDEX_USAGES = {"index_with_lookup", "covering_index"}
+
+
+@pytest.fixture(scope="function")
+def temporal_indexed_backend(mysql_backend_single):
+    mysql_backend_single.executescript(_SETUP_SQL)
+    yield mysql_backend_single
+    try:
+        mysql_backend_single.executescript(_CLEANUP_SQL)
+    except Exception:
+        pass
+
+
+@pytest_asyncio.fixture(scope="function")
+async def async_temporal_indexed_backend(async_mysql_backend):
+    await async_mysql_backend.executescript(_SETUP_SQL)
+    yield async_mysql_backend
+    try:
+        await async_mysql_backend.executescript(_CLEANUP_SQL)
+    except Exception:
+        pass
+
+
+def _row_keys(result: MySQLExplainResult) -> set:
+    return {row.key for row in result.rows if row.key}
+
+
+def _range_filter(dialect, column_name: str, start: str, end: str):
+    return LogicalPredicate(
+        dialect,
+        "AND",
+        ComparisonPredicate(
+            dialect, ">=", Column(dialect, column_name), Literal(dialect, start)
+        ),
+        ComparisonPredicate(dialect, "<", Column(dialect, column_name), Literal(dialect, end)),
+    )
+
+
+def _category_created_filter(dialect):
+    return LogicalPredicate(
+        dialect,
+        "AND",
+        ComparisonPredicate(
+            dialect, "=", Column(dialect, "category"), Literal(dialect, "deploy")
+        ),
+        _range_filter(
+            dialect,
+            "created_at",
+            "2026-02-20 00:00:00",
+            "2026-03-10 00:00:00",
+        ),
+    )
+
+
+def _datetime_expression_query(dialect):
+    return QueryExpression(
+        dialect,
+        select=[
+            Column(dialect, "id"),
+            extract(dialect, "year", Column(dialect, "created_at")).as_(
+                "created_year"
+            ),
+            date_add(dialect, Column(dialect, "started_at"), 30, "minute").as_(
+                "starts_plus_30m"
+            ),
+            date_sub(dialect, Column(dialect, "ended_at"), 1, "hour").as_(
+                "ended_minus_1h"
+            ),
+            date_diff(
+                dialect, "minute", Column(dialect, "started_at"), Column(dialect, "ended_at")
+            ).as_("duration_minutes"),
+        ],
+        from_=TableExpression(dialect, "explain_temporal_events"),
+        where=_category_created_filter(dialect),
+        order_by=OrderByClause(
+            dialect,
+            [(Column(dialect, "category"), "ASC"), (Column(dialect, "created_at"), "ASC")],
+        ),
+    )
+
+
+class TestSyncMySQLDateTimeIntervalExplainExamples:
+    def test_created_at_range_uses_datetime_index(self, temporal_indexed_backend):
+        dialect = temporal_indexed_backend.dialect
+        result = temporal_indexed_backend.explain(
+            QueryExpression(
+                dialect,
+                select=[Column(dialect, "id"), Column(dialect, "created_at")],
+                from_=TableExpression(dialect, "explain_temporal_events"),
+                where=_range_filter(
+                    dialect,
+                    "created_at",
+                    "2026-02-20 00:00:00",
+                    "2026-03-10 00:00:00",
+                ),
+            )
+        )
+
+        assert isinstance(result, MySQLExplainResult)
+        assert result.analyze_index_usage() in _INDEX_USAGES
+        assert result.is_index_used is True
+        assert result.is_full_scan is False
+        assert _row_keys(result) & {"idx_temporal_created_at", "idx_temporal_category_created"}
+
+    def test_category_created_range_uses_composite_datetime_index(
+        self, temporal_indexed_backend
+    ):
+        dialect = temporal_indexed_backend.dialect
+        result = temporal_indexed_backend.explain(
+            QueryExpression(
+                dialect,
+                select=[
+                    Column(dialect, "id"),
+                    Column(dialect, "category"),
+                    Column(dialect, "created_at"),
+                ],
+                from_=TableExpression(dialect, "explain_temporal_events"),
+                where=_category_created_filter(dialect),
+            )
+        )
+
+        assert result.analyze_index_usage() in _INDEX_USAGES
+        assert result.is_index_used is True
+        assert result.is_full_scan is False
+        assert "idx_temporal_category_created" in _row_keys(result)
+
+    def test_covering_datetime_index_query_is_detected(self, temporal_indexed_backend):
+        dialect = temporal_indexed_backend.dialect
+        result = temporal_indexed_backend.explain(
+            QueryExpression(
+                dialect,
+                select=[Column(dialect, "category"), Column(dialect, "created_at")],
+                from_=TableExpression(dialect, "explain_temporal_events"),
+                where=_category_created_filter(dialect),
+            )
+        )
+
+        assert result.analyze_index_usage() in _INDEX_USAGES
+        assert result.is_index_used is True
+        assert result.is_full_scan is False
+        assert "idx_temporal_category_created" in _row_keys(result)
+
+    def test_datetime_interval_expressions_work_with_indexed_filter(
+        self, temporal_indexed_backend
+    ):
+        dialect = temporal_indexed_backend.dialect
+        query = _datetime_expression_query(dialect)
+
+        explain_result = temporal_indexed_backend.explain(query)
+        assert explain_result.analyze_index_usage() in _INDEX_USAGES
+        assert explain_result.is_index_used is True
+        assert "idx_temporal_category_created" in _row_keys(explain_result)
+
+        query_result = temporal_indexed_backend.execute(
+            *query.to_sql(),
+            options=_DQL_OPTIONS,
+        )
+        rows = query_result.data
+
+        assert rows is not None
+        assert len(rows) == 3
+        assert rows[0]["created_year"] == 2026
+        assert rows[0]["duration_minutes"] == 30
+        assert rows[0]["starts_plus_30m"] is not None
+        assert rows[0]["ended_minus_1h"] is not None
+
+
+class TestAsyncMySQLDateTimeIntervalExplainExamples:
+    @pytest.mark.asyncio
+    async def test_category_created_range_uses_composite_datetime_index(
+        self, async_temporal_indexed_backend
+    ):
+        dialect = async_temporal_indexed_backend.dialect
+        result = await async_temporal_indexed_backend.explain(
+            QueryExpression(
+                dialect,
+                select=[
+                    Column(dialect, "id"),
+                    Column(dialect, "category"),
+                    Column(dialect, "created_at"),
+                ],
+                from_=TableExpression(dialect, "explain_temporal_events"),
+                where=_category_created_filter(dialect),
+            )
+        )
+
+        assert result.is_index_used is True
+        assert result.is_full_scan is False
+        assert "idx_temporal_category_created" in _row_keys(result)
+
+    @pytest.mark.asyncio
+    async def test_datetime_interval_expressions_work_with_indexed_filter(
+        self, async_temporal_indexed_backend
+    ):
+        dialect = async_temporal_indexed_backend.dialect
+        query = _datetime_expression_query(dialect)
+
+        explain_result = await async_temporal_indexed_backend.explain(query)
+        assert explain_result.is_index_used is True
+        assert "idx_temporal_category_created" in _row_keys(explain_result)
+
+        query_result = await async_temporal_indexed_backend.execute(
+            *query.to_sql(),
+            options=_DQL_OPTIONS,
+        )
+        rows = query_result.data
+
+        assert rows is not None
+        assert len(rows) == 3
+        assert rows[0]["created_year"] == 2026
+        assert rows[0]["duration_minutes"] == 30

--- a/tests/rhosocial/activerecord_mysql_test/feature/backend/test_mysql_datetime_interval_expressions.py
+++ b/tests/rhosocial/activerecord_mysql_test/feature/backend/test_mysql_datetime_interval_expressions.py
@@ -1,0 +1,155 @@
+# tests/rhosocial/activerecord_mysql_test/feature/backend/test_mysql_datetime_interval_expressions.py
+"""Tests for MySQL datetime interval expressions."""
+
+import pytest
+
+from rhosocial.activerecord.backend.dialect.exceptions import UnsupportedFeatureError
+from rhosocial.activerecord.backend.expression import Column, Literal, QueryExpression
+from rhosocial.activerecord.backend.expression.functions import (
+    date_add,
+    date_diff,
+    date_part,
+    date_sub,
+    date_trunc,
+    extract,
+    interval,
+)
+from rhosocial.activerecord.backend.impl.mysql.dialect import MySQLDialect
+
+
+class TestMySQLDateTimeIntervalExpressions:
+    @pytest.mark.parametrize(
+        "field",
+        ["year", "month", "day", "hour", "minute", "second"],
+    )
+    def test_extract_datetime_fields(self, mysql_dialect: MySQLDialect, field: str):
+        expr = extract(mysql_dialect, field, Column(mysql_dialect, "created_at"))
+
+        sql, params = expr.to_sql()
+
+        assert sql == f"EXTRACT({field.upper()} FROM `created_at`)"
+        assert params == ()
+
+    def test_date_part_uses_extract_mapping(self, mysql_dialect: MySQLDialect):
+        expr = date_part(mysql_dialect, "day", Column(mysql_dialect, "created_at"))
+
+        sql, params = expr.to_sql()
+
+        assert sql == "EXTRACT(DAY FROM `created_at`)"
+        assert params == ()
+
+    @pytest.mark.parametrize(
+        "field,fmt",
+        [
+            ("year", "%Y-01-01 00:00:00"),
+            ("month", "%Y-%m-01 00:00:00"),
+            ("day", "%Y-%m-%d 00:00:00"),
+            ("hour", "%Y-%m-%d %H:00:00"),
+            ("minute", "%Y-%m-%d %H:%i:00"),
+            ("second", "%Y-%m-%d %H:%i:%s"),
+        ],
+    )
+    def test_date_trunc_datetime_fields(
+        self, mysql_dialect: MySQLDialect, field: str, fmt: str
+    ):
+        expr = date_trunc(mysql_dialect, field, Column(mysql_dialect, "created_at"))
+
+        sql, params = expr.to_sql()
+
+        assert sql == "CAST(DATE_FORMAT(`created_at`, %s) AS DATETIME)"
+        assert params == (fmt,)
+
+    def test_date_trunc_week_is_unsupported(self, mysql_dialect: MySQLDialect):
+        expr = date_trunc(mysql_dialect, "week", Column(mysql_dialect, "created_at"))
+
+        with pytest.raises(UnsupportedFeatureError):
+            expr.to_sql()
+
+    def test_interval_expression(self, mysql_dialect: MySQLDialect):
+        expr = interval(mysql_dialect, 2, "hour")
+
+        sql, params = expr.to_sql()
+
+        assert sql == "INTERVAL %s HOUR"
+        assert params == (2,)
+
+    def test_date_add_column_source(self, mysql_dialect: MySQLDialect):
+        expr = date_add(mysql_dialect, Column(mysql_dialect, "created_at"), 1, "day")
+
+        sql, params = expr.to_sql()
+
+        assert sql == "DATE_ADD(`created_at`, INTERVAL %s DAY)"
+        assert params == (1,)
+
+    def test_date_sub_interval_expression(self, mysql_dialect: MySQLDialect):
+        expr = date_sub(
+            mysql_dialect,
+            Column(mysql_dialect, "created_at"),
+            interval(mysql_dialect, 2, "hour"),
+        )
+
+        sql, params = expr.to_sql()
+
+        assert sql == "DATE_SUB(`created_at`, INTERVAL %s HOUR)"
+        assert params == (2,)
+
+    def test_date_add_literal_source_params_order(self, mysql_dialect: MySQLDialect):
+        expr = date_add(
+            mysql_dialect,
+            Literal(mysql_dialect, "2026-06-04 10:00:00"),
+            30,
+            "minute",
+        )
+
+        sql, params = expr.to_sql()
+
+        assert sql == "DATE_ADD(%s, INTERVAL %s MINUTE)"
+        assert params == ("2026-06-04 10:00:00", 30)
+
+    @pytest.mark.parametrize(
+        "unit",
+        ["year", "month", "week", "day", "hour", "minute", "second"],
+    )
+    def test_date_diff_supported_units(self, mysql_dialect: MySQLDialect, unit: str):
+        expr = date_diff(
+            mysql_dialect,
+            unit,
+            Column(mysql_dialect, "started_at"),
+            Column(mysql_dialect, "ended_at"),
+        )
+
+        sql, params = expr.to_sql()
+
+        assert sql == f"TIMESTAMPDIFF({unit.upper()}, `started_at`, `ended_at`)"
+        assert params == ()
+
+    def test_alias_and_cast(self, mysql_dialect: MySQLDialect):
+        expr = date_diff(
+            mysql_dialect,
+            "day",
+            Column(mysql_dialect, "started_at"),
+            Column(mysql_dialect, "ended_at"),
+        ).cast("SIGNED").as_("elapsed_days")
+
+        sql, params = expr.to_sql()
+
+        assert sql == (
+            "CAST(TIMESTAMPDIFF(DAY, `started_at`, `ended_at`) AS SIGNED) "
+            "AS `elapsed_days`"
+        )
+        assert params == ()
+
+    def test_query_expression_integration(self, mysql_dialect: MySQLDialect):
+        shifted = date_add(mysql_dialect, Column(mysql_dialect, "created_at"), 1, "day")
+        query = QueryExpression(
+            mysql_dialect,
+            select=[extract(mysql_dialect, "year", Column(mysql_dialect, "created_at"))],
+            from_="events",
+            where=shifted > Literal(mysql_dialect, "2026-01-01"),
+        )
+
+        sql, params = query.to_sql()
+
+        assert "EXTRACT(YEAR FROM `created_at`)" in sql
+        assert "DATE_ADD(`created_at`, INTERVAL %s DAY) > %s" in sql
+        assert params == (1, "2026-01-01")


### PR DESCRIPTION
## Description

Adds MySQL dialect support for datetime interval expressions and EXPLAIN-backed index usage verification.

This PR covers:

- MySQL dialect formatting for datetime extraction (`EXTRACT`), datetime add/subtract (`DATE_ADD`/`DATE_SUB`), and datetime diff (`TIMESTAMPDIFF`) operations.
- MySQL-specific temporal expression factory implementations in `backend.impl.mysql.functions`.
- EXPLAIN example tests that validate datetime range predicates use expected indexes when temporal expressions appear in the `SELECT` list.
- Sync/async test parity for all datetime interval EXPLAIN scenarios.

Related to [python-activerecord#99](https://github.com/rhosocial/python-activerecord/pull/99) (coordinated backend support for datetime interval feature).

## Type of change

- [x] `feat`: A new feature
- [x] `test`: Adding missing tests or correcting existing tests (for the new feature)

## Breaking Change

- [ ] Yes, for end-users (backward-incompatible API changes)
- [ ] Yes, for backend developers (internal architectural changes that may affect custom implementations)
- [x] No breaking changes

**Impact on End-Users:**
No backward-incompatible changes are expected for typical end-user applications.

**Impact on Backend Developers (Custom Implementations):**
No existing formatter signatures were removed. Custom dialects can opt into the new temporal expression support by implementing the corresponding formatter methods.

**Applicable `rhosocial-activerecord` Version Range:**
`>=1.0.0.dev18,<2.0.0`

## Related Repositories/Packages

Coordinated backend support has been added separately for:

- [python-activerecord#99](https://github.com/rhosocial/python-activerecord/pull/99) (core expression system)
- `python-activerecord-postgres`

## Testing

- [x] I have added new tests to cover my changes.
- [x] I have updated existing tests to reflect my changes.
- [x] All existing tests pass for the targeted test scope.
- [x] This change has been tested on MySQL 8.0+.

**Test Plan:**

```bash
source .venv3.8/bin/activate
pytest tests/rhosocial/activerecord_mysql_test/feature/backend/test_mysql_datetime_interval_explain_examples.py -v
pytest tests/rhosocial/activerecord_mysql_test/feature/backend/test_mysql_datetime_interval_expressions.py -v
pytest tests/rhosocial/activerecord_mysql_test/feature/backend/test_backend_explain.py -v
deactivate
```

Results:
- `6 passed` — MySQL datetime interval EXPLAIN examples
- `26 passed` — MySQL datetime interval expression tests
- `21 passed` — MySQL backend explain tests

**MySQL test conclusions:**

- The new datetime interval feature is exercised through the expression system using `QueryExpression`, `Column`, `Literal`, `ComparisonPredicate`, `LogicalPredicate`, `OrderByClause`, and temporal expression factories.
- Temporal expressions can participate in full SELECT queries while datetime range predicates remain index-friendly in the WHERE clause.
- MySQL `EXPLAIN` results confirm that indexed datetime predicates produce efficient plans using `idx_temporal_category_created`, `idx_temporal_created_at`, or `idx_temporal_started_ended` indexes instead of full table scans.
- Combining `extract`, `date_add`, `date_sub`, and `date_diff` in the SELECT list does not prevent the `category + created_at` indexed filter from being used.
- The queries are executed against real MySQL tables, validating both generated SQL semantics and runtime results, including extracted year values, shifted timestamps, and 30-minute duration calculations.

## Checklist

- [x] My code follows the project's code style guidelines.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation (Docstrings, `README.md`, etc.).
- [x] My changes generate no new warnings in the targeted test scope.
- [ ] I have added a Changelog fragment (`changelog.d/<issue_number>.<type>.md`).
- [x] I have verified that my changes do not introduce SQL injection vulnerabilities.
- [x] I have checked for potential performance regressions.

## Additional Notes

The EXPLAIN example tests intentionally build verification queries through `QueryExpression` and predicate/expression objects rather than raw SQL strings, so they validate end-to-end expression semantics as well as backend-specific SQL generation.